### PR TITLE
add note to press Enter twice to escape during shutdown

### DIFF
--- a/CGame.cpp
+++ b/CGame.cpp
@@ -222,7 +222,7 @@ void WaitForEnter()
     if(waited)
         return;
     waited = true;
-    std::cout << "\n\nPress ENTER to close this window . . ." << std::endl;
+    std::cout << "\n\nPress ENTER *twice* to close this window . . ." << std::endl;
     std::cin.clear();
     std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
     std::cin.get();


### PR DESCRIPTION
this is not a fix, but it leaves users less confused I guess. 

#17 