### PR TITLE
Automatic fixes of clang-tidy warnings: misc-unused-using-decls,moder…

### DIFF
--- a/CIO/CFile.cpp
+++ b/CIO/CFile.cpp
@@ -32,10 +32,10 @@ bool CFile::loadPAL = false;
 
 void CFile::init()
 {
-    bmpArray = &global::bmpArray[0];
-    shadowArray = &global::shadowArray[0];
-    palArray = &global::palArray[0];
-    palActual = &global::palArray[0];
+    bmpArray = global::bmpArray.data();
+    shadowArray = global::shadowArray.data();
+    palArray = global::palArray.data();
+    palActual = global::palArray.data();
     loadPAL = false;
 }
 

--- a/CIO/CTextfield.cpp
+++ b/CIO/CTextfield.cpp
@@ -110,7 +110,7 @@ void CTextfield::setY(int y)
 
 void CTextfield::setText(const std::string& text)
 {
-    char* txtPtr = &this->text_[0];
+    char* txtPtr = this->text_.data();
     int col_ctr = 1, row_ctr = 1;
 
     for(char c : text)

--- a/SGE/include/SGE/sge_shape.h
+++ b/SGE/include/SGE/sge_shape.h
@@ -52,10 +52,10 @@ public:
     virtual void clear(Uint32 color) = 0;                               // Clears to color
     virtual void clear(SDL_Surface* src, Sint16 srcX, Sint16 srcY) = 0; // Clears by blitting src
 
-    inline SDL_Rect get_pos() const { return current_pos; }   // Returns the current position
-    inline SDL_Rect get_last_pos() const { return last_pos; } // Returns the last updated position
+    SDL_Rect get_pos() const { return current_pos; }   // Returns the current position
+    SDL_Rect get_last_pos() const { return last_pos; } // Returns the last updated position
 
-    inline SDL_Surface* get_dest() const { return dest; }
+    SDL_Surface* get_dest() const { return dest; }
 
     /*
     //NW N NE
@@ -66,37 +66,37 @@ public:
     //
     //Returns some usefull coords in shape (current)
     */
-    inline Sint16 c_x() const { return current_pos.x + current_pos.w / 2; }
-    inline Sint16 c_y() const { return current_pos.y + current_pos.h / 2; }
+    Sint16 c_x() const { return current_pos.x + current_pos.w / 2; }
+    Sint16 c_y() const { return current_pos.y + current_pos.h / 2; }
 
-    inline Sint16 nw_x() const { return current_pos.x; }
-    inline Sint16 nw_y() const { return current_pos.y; }
+    Sint16 nw_x() const { return current_pos.x; }
+    Sint16 nw_y() const { return current_pos.y; }
 
-    inline Sint16 n_x() const { return current_pos.x + current_pos.w / 2; }
-    inline Sint16 n_y() const { return current_pos.y; }
+    Sint16 n_x() const { return current_pos.x + current_pos.w / 2; }
+    Sint16 n_y() const { return current_pos.y; }
 
-    inline Sint16 ne_x() const { return current_pos.x + current_pos.w - 1; }
-    inline Sint16 ne_y() const { return current_pos.y; }
+    Sint16 ne_x() const { return current_pos.x + current_pos.w - 1; }
+    Sint16 ne_y() const { return current_pos.y; }
 
-    inline Sint16 e_x() const { return current_pos.x + current_pos.w - 1; }
-    inline Sint16 e_y() const { return current_pos.y + current_pos.h / 2; }
+    Sint16 e_x() const { return current_pos.x + current_pos.w - 1; }
+    Sint16 e_y() const { return current_pos.y + current_pos.h / 2; }
 
-    inline Sint16 se_x() const { return current_pos.x + current_pos.w - 1; }
-    inline Sint16 se_y() const { return current_pos.y + current_pos.h - 1; }
+    Sint16 se_x() const { return current_pos.x + current_pos.w - 1; }
+    Sint16 se_y() const { return current_pos.y + current_pos.h - 1; }
 
-    inline Sint16 s_x() const { return current_pos.x + current_pos.w / 2; }
-    inline Sint16 s_y() const { return current_pos.y + current_pos.h - 1; }
+    Sint16 s_x() const { return current_pos.x + current_pos.w / 2; }
+    Sint16 s_y() const { return current_pos.y + current_pos.h - 1; }
 
-    inline Sint16 sw_x() const { return current_pos.x; }
-    inline Sint16 sw_y() const { return current_pos.y + current_pos.h - 1; }
+    Sint16 sw_x() const { return current_pos.x; }
+    Sint16 sw_y() const { return current_pos.y + current_pos.h - 1; }
 
-    inline Sint16 w_x() const { return current_pos.x; }
-    inline Sint16 w_y() const { return current_pos.y + current_pos.h / 2; }
+    Sint16 w_x() const { return current_pos.x; }
+    Sint16 w_y() const { return current_pos.y + current_pos.h / 2; }
 
-    inline Sint16 get_xpos() const { return current_pos.x; }
-    inline Sint16 get_ypos() const { return current_pos.y; }
-    inline Uint16 get_w() const { return current_pos.w; }
-    inline Uint16 get_h() const { return current_pos.h; }
+    Sint16 get_xpos() const { return current_pos.x; }
+    Sint16 get_ypos() const { return current_pos.y; }
+    Uint16 get_w() const { return current_pos.w; }
+    Uint16 get_h() const { return current_pos.h; }
 };
 
 //==================================================================================

--- a/SGE/sge_shape.cpp
+++ b/SGE/sge_shape.cpp
@@ -384,7 +384,7 @@ void sge_ssprite::skip_frame(int skips)
 bool sge_ssprite::update()
 {
     move(xvel, yvel);
-    return !((xvel == 0) && (yvel == 0));
+    return (xvel != 0) || (yvel != 0);
 }
 
 void sge_ssprite::set_seq(int start, int stop, playing_mode mode)


### PR DESCRIPTION
…nize-use-auto,performance-inefficient-vector-operation,performance-move-const-arg,readability-container-size-empty,readability-redundant-member-init,performance-noexcept-swap,readability-redundant-inline-specifier,readability-container-data-pointer