### PR TITLE
Change x,y->Point w,h->Extent

### DIFF
--- a/CDebug.cpp
+++ b/CDebug.cpp
@@ -20,7 +20,7 @@ CDebug::CDebug(void dbgCallback(int), int quitParam)
     dbgWnd = global::s2->RegisterWindow(
       std::make_unique<CWindow>(dbgCallback, quitParam, Position(0, 0), Extent(540, 130), "Debugger", WINDOW_GREEN1,
                                 WINDOW_CLOSE | WINDOW_MOVE | WINDOW_MINIMIZE | WINDOW_RESIZE));
-    dbgWnd->addText("Debugger started", 0, 0, fontsize);
+    dbgWnd->addText("Debugger started", Point16(0, 0), fontsize);
     this->dbgCallback_ = dbgCallback;
     FrameCounterText = nullptr;
     FramesPerSecText = nullptr;
@@ -59,33 +59,33 @@ CDebug::CDebug(void dbgCallback(int), int quitParam)
     global::s2->RegisterCallback(dbgCallback);
 
     // add buttons for in-/decrementing msWait
-    dbgWnd->addButton(dbgCallback, DECREMENT_MSWAIT, 75, 30, 15, 15, BUTTON_GREY, "-");
-    dbgWnd->addButton(dbgCallback, SETZERO_MSWAIT, 90, 30, 15, 15, BUTTON_GREY, "0");
-    dbgWnd->addButton(dbgCallback, INCREMENT_MSWAIT, 105, 30, 15, 15, BUTTON_GREY, "+");
+    dbgWnd->addButton(dbgCallback, DECREMENT_MSWAIT, Point16(75, 30), Extent16(15, 15), BUTTON_GREY, "-");
+    dbgWnd->addButton(dbgCallback, SETZERO_MSWAIT, Point16(90, 30), Extent16(15, 15), BUTTON_GREY, "0");
+    dbgWnd->addButton(dbgCallback, INCREMENT_MSWAIT, Point16(105, 30), Extent16(15, 15), BUTTON_GREY, "+");
 
     // we draw a vertical line to separate map data on the right side from things on the left side
-    dbgWnd->addText("#", 240, 10, fontsize);
-    dbgWnd->addText("#", 240, 20, fontsize);
-    dbgWnd->addText("#", 240, 30, fontsize);
-    dbgWnd->addText("#", 240, 40, fontsize);
-    dbgWnd->addText("#", 240, 50, fontsize);
-    dbgWnd->addText("#", 240, 60, fontsize);
-    dbgWnd->addText("#", 240, 70, fontsize);
-    dbgWnd->addText("#", 240, 80, fontsize);
-    dbgWnd->addText("#", 240, 90, fontsize);
-    dbgWnd->addText("#", 240, 100, fontsize);
-    dbgWnd->addText("#", 240, 110, fontsize);
-    dbgWnd->addText("#", 240, 120, fontsize);
-    dbgWnd->addText("#", 240, 130, fontsize);
-    dbgWnd->addText("#", 240, 140, fontsize);
-    dbgWnd->addText("#", 240, 150, fontsize);
-    dbgWnd->addText("#", 240, 160, fontsize);
-    dbgWnd->addText("#", 240, 170, fontsize);
-    dbgWnd->addText("#", 240, 180, fontsize);
-    dbgWnd->addText("#", 240, 190, fontsize);
-    dbgWnd->addText("#", 240, 200, fontsize);
-    dbgWnd->addText("#", 240, 210, fontsize);
-    dbgWnd->addText("#", 240, 220, fontsize);
+    dbgWnd->addText("#", Point16(240, 10), fontsize);
+    dbgWnd->addText("#", Point16(240, 20), fontsize);
+    dbgWnd->addText("#", Point16(240, 30), fontsize);
+    dbgWnd->addText("#", Point16(240, 40), fontsize);
+    dbgWnd->addText("#", Point16(240, 50), fontsize);
+    dbgWnd->addText("#", Point16(240, 60), fontsize);
+    dbgWnd->addText("#", Point16(240, 70), fontsize);
+    dbgWnd->addText("#", Point16(240, 80), fontsize);
+    dbgWnd->addText("#", Point16(240, 90), fontsize);
+    dbgWnd->addText("#", Point16(240, 100), fontsize);
+    dbgWnd->addText("#", Point16(240, 110), fontsize);
+    dbgWnd->addText("#", Point16(240, 120), fontsize);
+    dbgWnd->addText("#", Point16(240, 130), fontsize);
+    dbgWnd->addText("#", Point16(240, 140), fontsize);
+    dbgWnd->addText("#", Point16(240, 150), fontsize);
+    dbgWnd->addText("#", Point16(240, 160), fontsize);
+    dbgWnd->addText("#", Point16(240, 170), fontsize);
+    dbgWnd->addText("#", Point16(240, 180), fontsize);
+    dbgWnd->addText("#", Point16(240, 190), fontsize);
+    dbgWnd->addText("#", Point16(240, 200), fontsize);
+    dbgWnd->addText("#", Point16(240, 210), fontsize);
+    dbgWnd->addText("#", Point16(240, 220), fontsize);
 }
 
 CDebug::~CDebug()
@@ -116,7 +116,7 @@ void CDebug::sendParam(int Param)
 void CDebug::actualizeData()
 {
     if(!FrameCounterText)
-        FrameCounterText = dbgWnd->addText("", 0, 10, fontsize);
+        FrameCounterText = dbgWnd->addText("", Point16(0, 10), fontsize);
     // write new FrameCounterText and draw it
     FrameCounterText->setText("Actual Frame: " + std::to_string(global::s2->FrameCounter));
 
@@ -126,7 +126,7 @@ void CDebug::actualizeData()
     {
         // write new FramesPerSecText and draw it
         if(!FramesPerSecText)
-            FramesPerSecText = dbgWnd->addText("", 0, 20, fontsize);
+            FramesPerSecText = dbgWnd->addText("", Point16(0, 20), fontsize);
         FramesPerSecText->setText(
           helpers::format("Frames per Sec: %.2f", tmpFrameCtr / (((float)SDL_GetTicks() - tmpTickCtr) / 1000)));
         // set new values
@@ -137,13 +137,13 @@ void CDebug::actualizeData()
 
     // del msWaitText before drawing new
     if(!msWaitText)
-        msWaitText = dbgWnd->addText("", 0, 35, fontsize);
+        msWaitText = dbgWnd->addText("", Point16(0, 35), fontsize);
     // write new msWaitText and draw it
     msWaitText->setText("Wait: " + std::to_string(global::s2->msWait));
 
     // del MouseText before drawing new
     if(!MouseText)
-        MouseText = dbgWnd->addText("", 0, 50, fontsize);
+        MouseText = dbgWnd->addText("", Point16(0, 50), fontsize);
     // write new MouseText and draw it
     const char* clickedStr =
       global::s2->Cursor.clicked ?
@@ -155,24 +155,24 @@ void CDebug::actualizeData()
 
     // del RegisteredMenusText before drawing new
     if(!RegisteredMenusText)
-        RegisteredMenusText = dbgWnd->addText("", 0, 60, fontsize);
+        RegisteredMenusText = dbgWnd->addText("", Point16(0, 60), fontsize);
     // write new RegisteredMenusText and draw it
     RegisteredMenusText->setText(helpers::format("Registered Menus: %d", global::s2->Menus.size()));
 
     // del RegisteredWindowsText before drawing new
     if(!RegisteredWindowsText)
-        RegisteredWindowsText = dbgWnd->addText("", 0, 70, fontsize);
+        RegisteredWindowsText = dbgWnd->addText("", Point16(0, 70), fontsize);
     // write new RegisteredWindowsText and draw it
     RegisteredWindowsText->setText(helpers::format("Registered Windows: %d", global::s2->Windows.size()));
 
     // del RegisteredCallbacksText before drawing new
     if(!RegisteredCallbacksText)
-        RegisteredCallbacksText = dbgWnd->addText("", 0, 80, fontsize);
+        RegisteredCallbacksText = dbgWnd->addText("", Point16(0, 80), fontsize);
     // write new RegisteredCallbacksText and draw it
     RegisteredCallbacksText->setText(helpers::format("Registered Callbacks: %d", global::s2->Callbacks.size()));
 
     if(!DisplayRectText)
-        DisplayRectText = dbgWnd->addText("", 0, 90, fontsize);
+        DisplayRectText = dbgWnd->addText("", Point16(0, 90), fontsize);
     auto const displayRect = MapObj->getDisplayRect();
     DisplayRectText->setText(helpers::format("DisplayRect: (%d,%d)->(%d,%d)\n= size(%d, %d)", displayRect.left,
                                              displayRect.top, displayRect.right, displayRect.bottom,
@@ -186,86 +186,86 @@ void CDebug::actualizeData()
         const MapNode& vertex = map->getVertex(MapObj->Vertex_);
 
         if(!MapNameText)
-            MapNameText = dbgWnd->addText("", 260, 10, fontsize);
+            MapNameText = dbgWnd->addText("", Point16(260, 10), fontsize);
         MapNameText->setText("Map Name: " + map->getName());
         if(!MapSizeText)
-            MapSizeText = dbgWnd->addText("", 260, 20, fontsize);
+            MapSizeText = dbgWnd->addText("", Point16(260, 20), fontsize);
         MapSizeText->setText(helpers::format("Width: %d  Height: %d", map->width, map->height));
         if(!MapAuthorText)
-            MapAuthorText = dbgWnd->addText("", 260, 30, fontsize);
+            MapAuthorText = dbgWnd->addText("", Point16(260, 30), fontsize);
         MapAuthorText->setText("Author: " + map->getAuthor());
         if(!MapTypeText)
-            MapTypeText = dbgWnd->addText("", 260, 40, fontsize);
+            MapTypeText = dbgWnd->addText("", Point16(260, 40), fontsize);
         const char* ltStr =
           map->type == MAP_GREENLAND ?
             "Greenland" :
             (map->type == MAP_WASTELAND ? "Wasteland" : (map->type == MAP_WINTERLAND ? "Winterland" : "Unknown"));
         MapTypeText->setText(helpers::format("Type: %d (%s)", map->type, ltStr));
         if(!MapPlayerText)
-            MapPlayerText = dbgWnd->addText("", 260, 50, fontsize);
+            MapPlayerText = dbgWnd->addText("", Point16(260, 50), fontsize);
         MapPlayerText->setText(helpers::format("Player: %d", map->player));
         if(!VertexText)
-            VertexText = dbgWnd->addText("", 260, 60, fontsize);
+            VertexText = dbgWnd->addText("", Point16(260, 60), fontsize);
         VertexText->setText(helpers::format("Vertex: %d, %d", MapObj->Vertex_.x, MapObj->Vertex_.y));
         if(!VertexDataText)
-            VertexDataText = dbgWnd->addText("", 260, 70, fontsize);
+            VertexDataText = dbgWnd->addText("", Point16(260, 70), fontsize);
         VertexDataText->setText(helpers::format("Vertex Data: x=%d, y=%d, z=%d i=%.2f h=%#04x", vertex.x, vertex.y,
                                                 vertex.z, ((float)vertex.i) / pow(2, 16), vertex.h));
         if(!VertexVectorText)
-            VertexVectorText = dbgWnd->addText("", 260, 80, fontsize);
+            VertexVectorText = dbgWnd->addText("", Point16(260, 80), fontsize);
         VertexVectorText->setText(helpers::format("Vertex Vector: (%.2f, %.2f, %.2f)", vertex.normVector.x,
                                                   vertex.normVector.y, vertex.normVector.z));
         if(!FlatVectorText)
-            FlatVectorText = dbgWnd->addText("", 260, 90, fontsize);
+            FlatVectorText = dbgWnd->addText("", Point16(260, 90), fontsize);
         FlatVectorText->setText(helpers::format("Flat Vector: (%.2f, %.2f, %.2f)", vertex.flatVector.x,
                                                 vertex.flatVector.y, vertex.flatVector.z));
         if(!rsuTextureText)
-            rsuTextureText = dbgWnd->addText("", 260, 100, fontsize);
+            rsuTextureText = dbgWnd->addText("", Point16(260, 100), fontsize);
         rsuTextureText->setText(helpers::format("RSU-Texture: %#04x", vertex.rsuTexture));
         if(!usdTextureText)
-            usdTextureText = dbgWnd->addText("", 260, 110, fontsize);
+            usdTextureText = dbgWnd->addText("", Point16(260, 110), fontsize);
         usdTextureText->setText(helpers::format("USD-Texture: %#04x", vertex.usdTexture));
         if(!roadText)
-            roadText = dbgWnd->addText("", 260, 120, fontsize);
+            roadText = dbgWnd->addText("", Point16(260, 120), fontsize);
         roadText->setText(helpers::format("road: %#04x", vertex.road));
         if(!objectTypeText)
-            objectTypeText = dbgWnd->addText("", 260, 130, fontsize);
+            objectTypeText = dbgWnd->addText("", Point16(260, 130), fontsize);
         objectTypeText->setText(helpers::format("objectType: %#04x", vertex.objectType));
         if(!objectInfoText)
-            objectInfoText = dbgWnd->addText("", 260, 140, fontsize);
+            objectInfoText = dbgWnd->addText("", Point16(260, 140), fontsize);
         objectInfoText->setText(helpers::format("objectInfo: %#04x", vertex.objectInfo));
         if(!animalText)
-            animalText = dbgWnd->addText("", 260, 150, fontsize);
+            animalText = dbgWnd->addText("", Point16(260, 150), fontsize);
         animalText->setText(helpers::format("animal: %#04x", vertex.animal));
         if(!unknown1Text)
-            unknown1Text = dbgWnd->addText("", 260, 160, fontsize);
+            unknown1Text = dbgWnd->addText("", Point16(260, 160), fontsize);
         unknown1Text->setText(helpers::format("unknown1: %#04x", vertex.unknown1));
         if(!buildText)
-            buildText = dbgWnd->addText("", 260, 170, fontsize);
+            buildText = dbgWnd->addText("", Point16(260, 170), fontsize);
         buildText->setText(helpers::format("build: %#04x", vertex.build));
         if(!unknown2Text)
-            unknown2Text = dbgWnd->addText("", 260, 180, fontsize);
+            unknown2Text = dbgWnd->addText("", Point16(260, 180), fontsize);
         unknown2Text->setText(helpers::format("unknown2: %#04x", vertex.unknown2));
         if(!unknown3Text)
-            unknown3Text = dbgWnd->addText("", 260, 190, fontsize);
+            unknown3Text = dbgWnd->addText("", Point16(260, 190), fontsize);
         unknown3Text->setText(helpers::format("unknown3: %#04x", vertex.unknown3));
         if(!resourceText)
-            resourceText = dbgWnd->addText("", 260, 200, fontsize);
+            resourceText = dbgWnd->addText("", Point16(260, 200), fontsize);
         resourceText->setText(helpers::format("resource: %#04x", vertex.resource));
         if(!shadingText)
-            shadingText = dbgWnd->addText("", 260, 210, fontsize);
+            shadingText = dbgWnd->addText("", Point16(260, 210), fontsize);
         shadingText->setText(helpers::format("shading: %#04x", vertex.shading));
         if(!unknown5Text)
-            unknown5Text = dbgWnd->addText("", 260, 220, fontsize);
+            unknown5Text = dbgWnd->addText("", Point16(260, 220), fontsize);
         unknown5Text->setText(helpers::format("unknown5: %#04x", vertex.unknown5));
         if(!editorModeText)
-            editorModeText = dbgWnd->addText("", 260, 230, fontsize);
+            editorModeText = dbgWnd->addText("", Point16(260, 230), fontsize);
         editorModeText->setText(helpers::format("Editor --> Mode: %d Content: %#04x Content2: %#04x", MapObj->mode,
                                                 MapObj->modeContent, MapObj->modeContent2));
     } else
     {
         if(!MapNameText)
-            dbgWnd->addText("", 260, 10, fontsize);
+            dbgWnd->addText("", Point16(260, 10), fontsize);
         // write new MapNameText and draw it
         MapNameText->setText("No Map loaded!");
         if(MapSizeText)

--- a/CDebug.cpp
+++ b/CDebug.cpp
@@ -20,7 +20,7 @@ CDebug::CDebug(void dbgCallback(int), int quitParam)
     dbgWnd = global::s2->RegisterWindow(
       std::make_unique<CWindow>(dbgCallback, quitParam, Position(0, 0), Extent(540, 130), "Debugger", WINDOW_GREEN1,
                                 WINDOW_CLOSE | WINDOW_MOVE | WINDOW_MINIMIZE | WINDOW_RESIZE));
-    dbgWnd->addText("Debugger started", Point16(0, 0), fontsize);
+    dbgWnd->addText("Debugger started", Position(0, 0), fontsize);
     this->dbgCallback_ = dbgCallback;
     FrameCounterText = nullptr;
     FramesPerSecText = nullptr;
@@ -59,33 +59,33 @@ CDebug::CDebug(void dbgCallback(int), int quitParam)
     global::s2->RegisterCallback(dbgCallback);
 
     // add buttons for in-/decrementing msWait
-    dbgWnd->addButton(dbgCallback, DECREMENT_MSWAIT, Point16(75, 30), Extent16(15, 15), BUTTON_GREY, "-");
-    dbgWnd->addButton(dbgCallback, SETZERO_MSWAIT, Point16(90, 30), Extent16(15, 15), BUTTON_GREY, "0");
-    dbgWnd->addButton(dbgCallback, INCREMENT_MSWAIT, Point16(105, 30), Extent16(15, 15), BUTTON_GREY, "+");
+    dbgWnd->addButton(dbgCallback, DECREMENT_MSWAIT, Position(75, 30), Extent(15, 15), BUTTON_GREY, "-");
+    dbgWnd->addButton(dbgCallback, SETZERO_MSWAIT, Position(90, 30), Extent(15, 15), BUTTON_GREY, "0");
+    dbgWnd->addButton(dbgCallback, INCREMENT_MSWAIT, Position(105, 30), Extent(15, 15), BUTTON_GREY, "+");
 
     // we draw a vertical line to separate map data on the right side from things on the left side
-    dbgWnd->addText("#", Point16(240, 10), fontsize);
-    dbgWnd->addText("#", Point16(240, 20), fontsize);
-    dbgWnd->addText("#", Point16(240, 30), fontsize);
-    dbgWnd->addText("#", Point16(240, 40), fontsize);
-    dbgWnd->addText("#", Point16(240, 50), fontsize);
-    dbgWnd->addText("#", Point16(240, 60), fontsize);
-    dbgWnd->addText("#", Point16(240, 70), fontsize);
-    dbgWnd->addText("#", Point16(240, 80), fontsize);
-    dbgWnd->addText("#", Point16(240, 90), fontsize);
-    dbgWnd->addText("#", Point16(240, 100), fontsize);
-    dbgWnd->addText("#", Point16(240, 110), fontsize);
-    dbgWnd->addText("#", Point16(240, 120), fontsize);
-    dbgWnd->addText("#", Point16(240, 130), fontsize);
-    dbgWnd->addText("#", Point16(240, 140), fontsize);
-    dbgWnd->addText("#", Point16(240, 150), fontsize);
-    dbgWnd->addText("#", Point16(240, 160), fontsize);
-    dbgWnd->addText("#", Point16(240, 170), fontsize);
-    dbgWnd->addText("#", Point16(240, 180), fontsize);
-    dbgWnd->addText("#", Point16(240, 190), fontsize);
-    dbgWnd->addText("#", Point16(240, 200), fontsize);
-    dbgWnd->addText("#", Point16(240, 210), fontsize);
-    dbgWnd->addText("#", Point16(240, 220), fontsize);
+    dbgWnd->addText("#", Position(240, 10), fontsize);
+    dbgWnd->addText("#", Position(240, 20), fontsize);
+    dbgWnd->addText("#", Position(240, 30), fontsize);
+    dbgWnd->addText("#", Position(240, 40), fontsize);
+    dbgWnd->addText("#", Position(240, 50), fontsize);
+    dbgWnd->addText("#", Position(240, 60), fontsize);
+    dbgWnd->addText("#", Position(240, 70), fontsize);
+    dbgWnd->addText("#", Position(240, 80), fontsize);
+    dbgWnd->addText("#", Position(240, 90), fontsize);
+    dbgWnd->addText("#", Position(240, 100), fontsize);
+    dbgWnd->addText("#", Position(240, 110), fontsize);
+    dbgWnd->addText("#", Position(240, 120), fontsize);
+    dbgWnd->addText("#", Position(240, 130), fontsize);
+    dbgWnd->addText("#", Position(240, 140), fontsize);
+    dbgWnd->addText("#", Position(240, 150), fontsize);
+    dbgWnd->addText("#", Position(240, 160), fontsize);
+    dbgWnd->addText("#", Position(240, 170), fontsize);
+    dbgWnd->addText("#", Position(240, 180), fontsize);
+    dbgWnd->addText("#", Position(240, 190), fontsize);
+    dbgWnd->addText("#", Position(240, 200), fontsize);
+    dbgWnd->addText("#", Position(240, 210), fontsize);
+    dbgWnd->addText("#", Position(240, 220), fontsize);
 }
 
 CDebug::~CDebug()
@@ -116,7 +116,7 @@ void CDebug::sendParam(int Param)
 void CDebug::actualizeData()
 {
     if(!FrameCounterText)
-        FrameCounterText = dbgWnd->addText("", Point16(0, 10), fontsize);
+        FrameCounterText = dbgWnd->addText("", Position(0, 10), fontsize);
     // write new FrameCounterText and draw it
     FrameCounterText->setText("Actual Frame: " + std::to_string(global::s2->FrameCounter));
 
@@ -126,7 +126,7 @@ void CDebug::actualizeData()
     {
         // write new FramesPerSecText and draw it
         if(!FramesPerSecText)
-            FramesPerSecText = dbgWnd->addText("", Point16(0, 20), fontsize);
+            FramesPerSecText = dbgWnd->addText("", Position(0, 20), fontsize);
         FramesPerSecText->setText(
           helpers::format("Frames per Sec: %.2f", tmpFrameCtr / (((float)SDL_GetTicks() - tmpTickCtr) / 1000)));
         // set new values
@@ -137,13 +137,13 @@ void CDebug::actualizeData()
 
     // del msWaitText before drawing new
     if(!msWaitText)
-        msWaitText = dbgWnd->addText("", Point16(0, 35), fontsize);
+        msWaitText = dbgWnd->addText("", Position(0, 35), fontsize);
     // write new msWaitText and draw it
     msWaitText->setText("Wait: " + std::to_string(global::s2->msWait));
 
     // del MouseText before drawing new
     if(!MouseText)
-        MouseText = dbgWnd->addText("", Point16(0, 50), fontsize);
+        MouseText = dbgWnd->addText("", Position(0, 50), fontsize);
     // write new MouseText and draw it
     const char* clickedStr =
       global::s2->Cursor.clicked ?
@@ -155,24 +155,24 @@ void CDebug::actualizeData()
 
     // del RegisteredMenusText before drawing new
     if(!RegisteredMenusText)
-        RegisteredMenusText = dbgWnd->addText("", Point16(0, 60), fontsize);
+        RegisteredMenusText = dbgWnd->addText("", Position(0, 60), fontsize);
     // write new RegisteredMenusText and draw it
     RegisteredMenusText->setText(helpers::format("Registered Menus: %d", global::s2->Menus.size()));
 
     // del RegisteredWindowsText before drawing new
     if(!RegisteredWindowsText)
-        RegisteredWindowsText = dbgWnd->addText("", Point16(0, 70), fontsize);
+        RegisteredWindowsText = dbgWnd->addText("", Position(0, 70), fontsize);
     // write new RegisteredWindowsText and draw it
     RegisteredWindowsText->setText(helpers::format("Registered Windows: %d", global::s2->Windows.size()));
 
     // del RegisteredCallbacksText before drawing new
     if(!RegisteredCallbacksText)
-        RegisteredCallbacksText = dbgWnd->addText("", Point16(0, 80), fontsize);
+        RegisteredCallbacksText = dbgWnd->addText("", Position(0, 80), fontsize);
     // write new RegisteredCallbacksText and draw it
     RegisteredCallbacksText->setText(helpers::format("Registered Callbacks: %d", global::s2->Callbacks.size()));
 
     if(!DisplayRectText)
-        DisplayRectText = dbgWnd->addText("", Point16(0, 90), fontsize);
+        DisplayRectText = dbgWnd->addText("", Position(0, 90), fontsize);
     auto const displayRect = MapObj->getDisplayRect();
     DisplayRectText->setText(helpers::format("DisplayRect: (%d,%d)->(%d,%d)\n= size(%d, %d)", displayRect.left,
                                              displayRect.top, displayRect.right, displayRect.bottom,
@@ -186,86 +186,86 @@ void CDebug::actualizeData()
         const MapNode& vertex = map->getVertex(MapObj->Vertex_);
 
         if(!MapNameText)
-            MapNameText = dbgWnd->addText("", Point16(260, 10), fontsize);
+            MapNameText = dbgWnd->addText("", Position(260, 10), fontsize);
         MapNameText->setText("Map Name: " + map->getName());
         if(!MapSizeText)
-            MapSizeText = dbgWnd->addText("", Point16(260, 20), fontsize);
+            MapSizeText = dbgWnd->addText("", Position(260, 20), fontsize);
         MapSizeText->setText(helpers::format("Width: %d  Height: %d", map->width, map->height));
         if(!MapAuthorText)
-            MapAuthorText = dbgWnd->addText("", Point16(260, 30), fontsize);
+            MapAuthorText = dbgWnd->addText("", Position(260, 30), fontsize);
         MapAuthorText->setText("Author: " + map->getAuthor());
         if(!MapTypeText)
-            MapTypeText = dbgWnd->addText("", Point16(260, 40), fontsize);
+            MapTypeText = dbgWnd->addText("", Position(260, 40), fontsize);
         const char* ltStr =
           map->type == MAP_GREENLAND ?
             "Greenland" :
             (map->type == MAP_WASTELAND ? "Wasteland" : (map->type == MAP_WINTERLAND ? "Winterland" : "Unknown"));
         MapTypeText->setText(helpers::format("Type: %d (%s)", map->type, ltStr));
         if(!MapPlayerText)
-            MapPlayerText = dbgWnd->addText("", Point16(260, 50), fontsize);
+            MapPlayerText = dbgWnd->addText("", Position(260, 50), fontsize);
         MapPlayerText->setText(helpers::format("Player: %d", map->player));
         if(!VertexText)
-            VertexText = dbgWnd->addText("", Point16(260, 60), fontsize);
+            VertexText = dbgWnd->addText("", Position(260, 60), fontsize);
         VertexText->setText(helpers::format("Vertex: %d, %d", MapObj->Vertex_.x, MapObj->Vertex_.y));
         if(!VertexDataText)
-            VertexDataText = dbgWnd->addText("", Point16(260, 70), fontsize);
+            VertexDataText = dbgWnd->addText("", Position(260, 70), fontsize);
         VertexDataText->setText(helpers::format("Vertex Data: x=%d, y=%d, z=%d i=%.2f h=%#04x", vertex.x, vertex.y,
                                                 vertex.z, ((float)vertex.i) / pow(2, 16), vertex.h));
         if(!VertexVectorText)
-            VertexVectorText = dbgWnd->addText("", Point16(260, 80), fontsize);
+            VertexVectorText = dbgWnd->addText("", Position(260, 80), fontsize);
         VertexVectorText->setText(helpers::format("Vertex Vector: (%.2f, %.2f, %.2f)", vertex.normVector.x,
                                                   vertex.normVector.y, vertex.normVector.z));
         if(!FlatVectorText)
-            FlatVectorText = dbgWnd->addText("", Point16(260, 90), fontsize);
+            FlatVectorText = dbgWnd->addText("", Position(260, 90), fontsize);
         FlatVectorText->setText(helpers::format("Flat Vector: (%.2f, %.2f, %.2f)", vertex.flatVector.x,
                                                 vertex.flatVector.y, vertex.flatVector.z));
         if(!rsuTextureText)
-            rsuTextureText = dbgWnd->addText("", Point16(260, 100), fontsize);
+            rsuTextureText = dbgWnd->addText("", Position(260, 100), fontsize);
         rsuTextureText->setText(helpers::format("RSU-Texture: %#04x", vertex.rsuTexture));
         if(!usdTextureText)
-            usdTextureText = dbgWnd->addText("", Point16(260, 110), fontsize);
+            usdTextureText = dbgWnd->addText("", Position(260, 110), fontsize);
         usdTextureText->setText(helpers::format("USD-Texture: %#04x", vertex.usdTexture));
         if(!roadText)
-            roadText = dbgWnd->addText("", Point16(260, 120), fontsize);
+            roadText = dbgWnd->addText("", Position(260, 120), fontsize);
         roadText->setText(helpers::format("road: %#04x", vertex.road));
         if(!objectTypeText)
-            objectTypeText = dbgWnd->addText("", Point16(260, 130), fontsize);
+            objectTypeText = dbgWnd->addText("", Position(260, 130), fontsize);
         objectTypeText->setText(helpers::format("objectType: %#04x", vertex.objectType));
         if(!objectInfoText)
-            objectInfoText = dbgWnd->addText("", Point16(260, 140), fontsize);
+            objectInfoText = dbgWnd->addText("", Position(260, 140), fontsize);
         objectInfoText->setText(helpers::format("objectInfo: %#04x", vertex.objectInfo));
         if(!animalText)
-            animalText = dbgWnd->addText("", Point16(260, 150), fontsize);
+            animalText = dbgWnd->addText("", Position(260, 150), fontsize);
         animalText->setText(helpers::format("animal: %#04x", vertex.animal));
         if(!unknown1Text)
-            unknown1Text = dbgWnd->addText("", Point16(260, 160), fontsize);
+            unknown1Text = dbgWnd->addText("", Position(260, 160), fontsize);
         unknown1Text->setText(helpers::format("unknown1: %#04x", vertex.unknown1));
         if(!buildText)
-            buildText = dbgWnd->addText("", Point16(260, 170), fontsize);
+            buildText = dbgWnd->addText("", Position(260, 170), fontsize);
         buildText->setText(helpers::format("build: %#04x", vertex.build));
         if(!unknown2Text)
-            unknown2Text = dbgWnd->addText("", Point16(260, 180), fontsize);
+            unknown2Text = dbgWnd->addText("", Position(260, 180), fontsize);
         unknown2Text->setText(helpers::format("unknown2: %#04x", vertex.unknown2));
         if(!unknown3Text)
-            unknown3Text = dbgWnd->addText("", Point16(260, 190), fontsize);
+            unknown3Text = dbgWnd->addText("", Position(260, 190), fontsize);
         unknown3Text->setText(helpers::format("unknown3: %#04x", vertex.unknown3));
         if(!resourceText)
-            resourceText = dbgWnd->addText("", Point16(260, 200), fontsize);
+            resourceText = dbgWnd->addText("", Position(260, 200), fontsize);
         resourceText->setText(helpers::format("resource: %#04x", vertex.resource));
         if(!shadingText)
-            shadingText = dbgWnd->addText("", Point16(260, 210), fontsize);
+            shadingText = dbgWnd->addText("", Position(260, 210), fontsize);
         shadingText->setText(helpers::format("shading: %#04x", vertex.shading));
         if(!unknown5Text)
-            unknown5Text = dbgWnd->addText("", Point16(260, 220), fontsize);
+            unknown5Text = dbgWnd->addText("", Position(260, 220), fontsize);
         unknown5Text->setText(helpers::format("unknown5: %#04x", vertex.unknown5));
         if(!editorModeText)
-            editorModeText = dbgWnd->addText("", Point16(260, 230), fontsize);
+            editorModeText = dbgWnd->addText("", Position(260, 230), fontsize);
         editorModeText->setText(helpers::format("Editor --> Mode: %d Content: %#04x Content2: %#04x", MapObj->mode,
                                                 MapObj->modeContent, MapObj->modeContent2));
     } else
     {
         if(!MapNameText)
-            dbgWnd->addText("", Point16(260, 10), fontsize);
+            dbgWnd->addText("", Position(260, 10), fontsize);
         // write new MapNameText and draw it
         MapNameText->setText("No Map loaded!");
         if(MapSizeText)

--- a/CGame.cpp
+++ b/CGame.cpp
@@ -14,11 +14,11 @@
 #include <boost/filesystem.hpp>
 #include <boost/nowide/cstdio.hpp>
 #include <boost/program_options.hpp>
+#include <csignal>
+#include <cstdio>
 #include <exception>
 #include <iostream>
 #include <limits>
-#include <cstdio>
-#include <csignal>
 #ifdef _WIN32
 #    ifndef WIN32_LEAN_AND_MEAN
 #        define WIN32_LEAN_AND_MEAN

--- a/CGame.cpp
+++ b/CGame.cpp
@@ -26,7 +26,7 @@ boost::program_options::variables_map parse_cmdline_args(int argc, char* argv[])
 
 CGame::CGame(Extent GameResolution_, bool fullscreen_)
     : GameResolution(GameResolution_), fullscreen(fullscreen_), Running(true), showLoadScreen(true),
-      lastFps("", 0, 0, FontSize::Medium)
+      lastFps("", Point16{0, 0}, FontSize::Medium)
 {
     global::bmpArray.resize(MAXBOBBMP);
     global::shadowArray.resize(MAXBOBSHADOW);

--- a/CGame.cpp
+++ b/CGame.cpp
@@ -32,7 +32,7 @@ boost::program_options::variables_map parse_cmdline_args(int argc, char* argv[])
 
 CGame::CGame(Extent GameResolution_, bool fullscreen_)
     : GameResolution(GameResolution_), fullscreen(fullscreen_), Running(true), showLoadScreen(true),
-      lastFps("", Point16{0, 0}, FontSize::Medium)
+      lastFps("", Position{0, 0}, FontSize::Medium)
 {
     global::bmpArray.resize(MAXBOBBMP);
     global::shadowArray.resize(MAXBOBSHADOW);

--- a/CGame_Render.cpp
+++ b/CGame_Render.cpp
@@ -75,11 +75,11 @@ void CGame::Render()
             CFont::writeText(Surf_Display, "Movement locked (F9 or F10 to unlock)", Position(20, 40), FontSize::Large,
                              FontColor::Orange);
         else if(MapObj->isHorizontalMovementLocked())
-            CFont::writeText(Surf_Display, "Horizontal movement locked (F9 to unlock)", Position(20, 40), FontSize::Large,
-                             FontColor::Orange);
+            CFont::writeText(Surf_Display, "Horizontal movement locked (F9 to unlock)", Position(20, 40),
+                             FontSize::Large, FontColor::Orange);
         else if(MapObj->isVerticalMovementLocked())
-            CFont::writeText(Surf_Display, "Vertical movement locked (F10 to unlock)", Position(20, 40), FontSize::Large,
-                             FontColor::Orange);
+            CFont::writeText(Surf_Display, "Vertical movement locked (F10 to unlock)", Position(20, 40),
+                             FontSize::Large, FontColor::Orange);
     }
 
     // render active menus

--- a/CGame_Render.cpp
+++ b/CGame_Render.cpp
@@ -64,21 +64,21 @@ void CGame::Render()
         std::array<char, 100> textBuffer;
         // text for x and y of vertex (shown in upper left corner)
         std::snprintf(textBuffer.data(), textBuffer.size(), "%d    %d", MapObj->getVertexX(), MapObj->getVertexY());
-        CFont::writeText(Surf_Display, textBuffer.data(), 20, 20);
+        CFont::writeText(Surf_Display, textBuffer.data(), Position(20, 20));
         // text for MinReduceHeight and MaxRaiseHeight
         std::snprintf(textBuffer.data(), textBuffer.size(),
                       "min. height: %#04x/0x3C  max. height: %#04x/0x3C  NormalNull: 0x0A",
                       MapObj->getMinReduceHeight(), MapObj->getMaxRaiseHeight());
-        CFont::writeText(Surf_Display, textBuffer.data(), 100, 20);
+        CFont::writeText(Surf_Display, textBuffer.data(), Position(100, 20));
         // text for MovementLocked
         if(MapObj->isHorizontalMovementLocked() && MapObj->isVerticalMovementLocked())
-            CFont::writeText(Surf_Display, "Movement locked (F9 or F10 to unlock)", 20, 40, FontSize::Large,
+            CFont::writeText(Surf_Display, "Movement locked (F9 or F10 to unlock)", Position(20, 40), FontSize::Large,
                              FontColor::Orange);
         else if(MapObj->isHorizontalMovementLocked())
-            CFont::writeText(Surf_Display, "Horizontal movement locked (F9 to unlock)", 20, 40, FontSize::Large,
+            CFont::writeText(Surf_Display, "Horizontal movement locked (F9 to unlock)", Position(20, 40), FontSize::Large,
                              FontColor::Orange);
         else if(MapObj->isVerticalMovementLocked())
-            CFont::writeText(Surf_Display, "Vertical movement locked (F10 to unlock)", 20, 40, FontSize::Large,
+            CFont::writeText(Surf_Display, "Vertical movement locked (F10 to unlock)", Position(20, 40), FontSize::Large,
                              FontColor::Orange);
     }
 

--- a/CIO/CButton.cpp
+++ b/CIO/CButton.cpp
@@ -9,7 +9,7 @@
 #include "CFont.h"
 #include "CollisionDetection.h"
 
-CButton::CButton(void callback(int), int clickedParam, Point16 pos, Extent16 size, int color, const char* text,
+CButton::CButton(void callback(int), int clickedParam, Position pos, Extent size, int color, const char* text,
                  int button_picture)
     : pos_(pos), size_(size)
 {
@@ -91,7 +91,7 @@ void CButton::setColor(int color)
 void CButton::setMouseData(const SDL_MouseMotionEvent& motion)
 {
     // cursor is on the button (and mouse button not pressed while moving on the button)
-    if(IsPointInRect(Position(motion.x, motion.y), Rect(Position(pos_), Extent(size_))))
+    if(IsPointInRect(Position(motion.x, motion.y), Rect(pos_, size_)))
     {
         if(motion.state == SDL_RELEASED)
         {
@@ -115,8 +115,7 @@ void CButton::setMouseData(const SDL_MouseButtonEvent& button)
     if(button.button == SDL_BUTTON_LEFT)
     {
         // if mouse button is pressed ON the button, set marked=true
-        if((button.state == SDL_PRESSED)
-           && IsPointInRect(Position(button.x, button.y), Rect(Position(pos_), Extent(size_))))
+        if((button.state == SDL_PRESSED) && IsPointInRect(Position(button.x, button.y), Rect(pos_, size_)))
         {
             marked = true;
             clicked = true;
@@ -134,11 +133,11 @@ void CButton::setMouseData(const SDL_MouseButtonEvent& button)
 bool CButton::render()
 {
     // position in the Surface 'Surf_Button'
-    Uint16 pos_x = 0;
-    Uint16 pos_y = 0;
+    unsigned pos_x = 0;
+    unsigned pos_y = 0;
     // width and height of the button color source picture
-    Uint16 pic_w = 0;
-    Uint16 pic_h = 0;
+    unsigned pic_w = 0;
+    unsigned pic_h = 0;
     // foreground of the button --> marked or unmarked, NOT the picture
     int foreground;
 
@@ -164,34 +163,40 @@ bool CButton::render()
     else
         pic_h = global::bmpArray[pic_background].h;
 
-    while(pos_x + pic_w <= Surf_Button->w)
+    while(pos_x + pic_w <= static_cast<unsigned>(Surf_Button->w))
     {
-        while(pos_y + pic_h <= Surf_Button->h)
+        while(pos_y + pic_h <= static_cast<unsigned>(Surf_Button->h))
         {
-            CSurface::Draw(Surf_Button, global::bmpArray[pic_background].surface, pos_x, pos_y, 0, 0, pic_w, pic_h);
+            CSurface::Draw(Surf_Button, global::bmpArray[pic_background].surface,
+                           Position(static_cast<int>(pos_x), static_cast<int>(pos_y)), Extent(0, 0),
+                           Extent(pic_w, pic_h));
             pos_y += pic_h;
         }
 
-        if(Surf_Button->h - pos_y > 0)
-            CSurface::Draw(Surf_Button, global::bmpArray[pic_background].surface, pos_x, pos_y, 0, 0, pic_w,
-                           Surf_Button->h - pos_y);
+        if(pos_y < static_cast<unsigned>(Surf_Button->h))
+            CSurface::Draw(Surf_Button, global::bmpArray[pic_background].surface,
+                           Position(static_cast<int>(pos_x), static_cast<int>(pos_y)), Extent(0, 0),
+                           Extent(pic_w, static_cast<unsigned>(Surf_Button->h - pos_y)));
 
         pos_y = 0;
         pos_x += pic_w;
     }
 
-    if(Surf_Button->w - pos_x > 0)
+    if(pos_x < static_cast<unsigned>(Surf_Button->w))
     {
-        while(pos_y + pic_h <= Surf_Button->h)
+        while(pos_y + pic_h <= static_cast<unsigned>(Surf_Button->h))
         {
-            CSurface::Draw(Surf_Button, global::bmpArray[pic_background].surface, pos_x, pos_y, 0, 0,
-                           Surf_Button->w - pos_x, pic_h);
+            CSurface::Draw(Surf_Button, global::bmpArray[pic_background].surface,
+                           Position(static_cast<int>(pos_x), static_cast<int>(pos_y)), Extent(0, 0),
+                           Extent(static_cast<unsigned>(Surf_Button->w - pos_x), pic_h));
             pos_y += pic_h;
         }
 
-        if(Surf_Button->h - pos_y > 0)
-            CSurface::Draw(Surf_Button, global::bmpArray[pic_background].surface, pos_x, pos_y, 0, 0,
-                           Surf_Button->w - pos_x, Surf_Button->h - pos_y);
+        if(pos_y < static_cast<unsigned>(Surf_Button->h))
+            CSurface::Draw(
+              Surf_Button, global::bmpArray[pic_background].surface,
+              Position(static_cast<int>(pos_x), static_cast<int>(pos_y)), Extent(0, 0),
+              Extent(static_cast<unsigned>(Surf_Button->w - pos_x), static_cast<unsigned>(Surf_Button->h - pos_y)));
     }
 
     // draw partial black frame
@@ -200,45 +205,45 @@ bool CButton::render()
         // black frame is left and up
         // draw vertical line
         pos_x = 0;
-        for(int y = 0; y < size_.y; y++)
-            CSurface::DrawPixel_RGB(Surf_Button, pos_x, y, 0, 0, 0);
+        for(unsigned y = 0; y < size_.y; y++)
+            CSurface::DrawPixel_RGB(Surf_Button, Position(pos_x, y), 0, 0, 0);
 
         // draw vertical line
         pos_x = 1;
-        for(int y = 0; y < size_.y - 1; y++)
-            CSurface::DrawPixel_RGB(Surf_Button, pos_x, y, 0, 0, 0);
+        for(unsigned y = 0; y < size_.y - 1; y++)
+            CSurface::DrawPixel_RGB(Surf_Button, Position(pos_x, y), 0, 0, 0);
 
         // draw horizontal line
         pos_y = 0;
-        for(int x = 0; x < size_.x; x++)
-            CSurface::DrawPixel_RGB(Surf_Button, x, pos_y, 0, 0, 0);
+        for(unsigned x = 0; x < size_.x; x++)
+            CSurface::DrawPixel_RGB(Surf_Button, Position(x, pos_y), 0, 0, 0);
 
         // draw horizontal line
         pos_y = 1;
-        for(int x = 0; x < size_.x - 1; x++)
-            CSurface::DrawPixel_RGB(Surf_Button, x, pos_y, 0, 0, 0);
+        for(unsigned x = 0; x < size_.x - 1; x++)
+            CSurface::DrawPixel_RGB(Surf_Button, Position(x, pos_y), 0, 0, 0);
     } else
     {
         // black frame is right and down
         // draw vertical line
         pos_x = size_.x - 1;
-        for(int y = 0; y < size_.y; y++)
-            CSurface::DrawPixel_RGB(Surf_Button, pos_x, y, 0, 0, 0);
+        for(unsigned y = 0; y < size_.y; y++)
+            CSurface::DrawPixel_RGB(Surf_Button, Position(pos_x, y), 0, 0, 0);
 
         // draw vertical line
         pos_x = size_.x - 2;
-        for(int y = 1; y < size_.y; y++)
-            CSurface::DrawPixel_RGB(Surf_Button, pos_x, y, 0, 0, 0);
+        for(unsigned y = 1; y < size_.y; y++)
+            CSurface::DrawPixel_RGB(Surf_Button, Position(pos_x, y), 0, 0, 0);
 
         // draw horizontal line
         pos_y = size_.y - 1;
-        for(int x = 0; x < size_.x; x++)
-            CSurface::DrawPixel_RGB(Surf_Button, x, pos_y, 0, 0, 0);
+        for(unsigned x = 0; x < size_.x; x++)
+            CSurface::DrawPixel_RGB(Surf_Button, Position(x, pos_y), 0, 0, 0);
 
         // draw horizontal line
         pos_y = size_.y - 2;
-        for(int x = 1; x < size_.x; x++)
-            CSurface::DrawPixel_RGB(Surf_Button, x, pos_y, 0, 0, 0);
+        for(unsigned x = 1; x < size_.x; x++)
+            CSurface::DrawPixel_RGB(Surf_Button, Position(x, pos_y), 0, 0, 0);
     }
 
     // draw the foreground --> at first the color (marked or unmarked) and then the picture or text
@@ -263,41 +268,47 @@ bool CButton::render()
         foreground = pic_normal;
 
     // '-2' follows a few times, this means: beware overdrawing the right and lower frame
-    while(pos_x + pic_w <= Surf_Button->w - 2)
+    while(pos_x + pic_w <= static_cast<unsigned>(Surf_Button->w - 2))
     {
-        while(pos_y + pic_h <= Surf_Button->h - 2)
+        while(pos_y + pic_h <= static_cast<unsigned>(Surf_Button->h - 2))
         {
-            CSurface::Draw(Surf_Button, global::bmpArray[foreground].surface, pos_x, pos_y, 0, 0, pic_w, pic_h);
+            CSurface::Draw(Surf_Button, global::bmpArray[foreground].surface,
+                           Position(static_cast<int>(pos_x), static_cast<int>(pos_y)), Extent(0, 0),
+                           Extent(pic_w, pic_h));
             pos_y += pic_h;
         }
 
-        if(Surf_Button->h - 2 - pos_y > 0)
-            CSurface::Draw(Surf_Button, global::bmpArray[foreground].surface, pos_x, pos_y, 0, 0, pic_w,
-                           Surf_Button->h - 2 - pos_y);
+        if(pos_y + 2 < static_cast<unsigned>(Surf_Button->h))
+            CSurface::Draw(Surf_Button, global::bmpArray[foreground].surface,
+                           Position(static_cast<int>(pos_x), static_cast<int>(pos_y)), Extent(0, 0),
+                           Extent(pic_w, static_cast<unsigned>(Surf_Button->h - pos_y)));
 
         pos_y = 2;
         pos_x += pic_w;
     }
 
-    if(Surf_Button->w - 2 - pos_x > 0)
+    if(pos_x + 2 < static_cast<unsigned>(Surf_Button->w))
     {
-        while(pos_y + pic_h <= Surf_Button->h - 2)
+        while(pos_y + pic_h <= static_cast<unsigned>(Surf_Button->h - 2))
         {
-            CSurface::Draw(Surf_Button, global::bmpArray[foreground].surface, pos_x, pos_y, 0, 0,
-                           Surf_Button->w - 2 - pos_x, pic_h);
+            CSurface::Draw(Surf_Button, global::bmpArray[foreground].surface,
+                           Position(static_cast<int>(pos_x), static_cast<int>(pos_y)), Extent(0, 0),
+                           Extent(static_cast<unsigned>(Surf_Button->w - 2 - pos_x), pic_h));
             pos_y += pic_h;
         }
 
-        if(Surf_Button->h - 2 - pos_y > 0)
-            CSurface::Draw(Surf_Button, global::bmpArray[foreground].surface, pos_x, pos_y, 0, 0,
-                           Surf_Button->w - 2 - pos_x, Surf_Button->h - 2 - pos_y);
+        if(pos_y + 2 < static_cast<unsigned>(Surf_Button->h))
+            CSurface::Draw(Surf_Button, global::bmpArray[foreground].surface,
+                           Position(static_cast<int>(pos_x), static_cast<int>(pos_y)), Extent(0, 0),
+                           Extent(static_cast<unsigned>(Surf_Button->w - 2 - pos_x),
+                                  static_cast<unsigned>(Surf_Button->h - 2 - pos_y)));
     }
 
     // positioning the picture or write text
     if(button_picture >= 0)
     {
         // picture may not be bigger than the button
-        if(global::bmpArray[button_picture].w <= Surf_Button->w && global::bmpArray[button_picture].h <= Surf_Button->h)
+        if(size_.x <= static_cast<unsigned>(Surf_Button->w) && size_.y <= static_cast<unsigned>(Surf_Button->h))
         {
             // get coordinates of the left upper corner where to positionate the picture
             Position leftup = Position(Surf_Button->w, Surf_Button->h) / 2
@@ -310,8 +321,9 @@ bool CButton::render()
             button_text = "PIC";
         }
     } else if(button_text)
-        CFont::writeText(Surf_Button, button_text, Position(size_.x / 2, (size_.y - 11) / 2), FontSize::Medium,
-                         button_text_color, FontAlign::Middle);
+        CFont::writeText(Surf_Button, button_text,
+                         Position(static_cast<int>(size_.x / 2), static_cast<int>((size_.y - 11) / 2)),
+                         FontSize::Medium, button_text_color, FontAlign::Middle);
 
     return true;
 }

--- a/CIO/CButton.cpp
+++ b/CIO/CButton.cpp
@@ -133,11 +133,9 @@ void CButton::setMouseData(const SDL_MouseButtonEvent& button)
 bool CButton::render()
 {
     // position in the Surface 'Surf_Button'
-    unsigned pos_x = 0;
-    unsigned pos_y = 0;
+    Position pos{0, 0};
     // width and height of the button color source picture
-    unsigned pic_w = 0;
-    unsigned pic_h = 0;
+    Extent pic{0, 0};
     // foreground of the button --> marked or unmarked, NOT the picture
     int foreground;
 
@@ -154,49 +152,44 @@ bool CButton::render()
 
     // at first completly fill the background (not the fastest way, but simplier)
     if(size_.x <= global::bmpArray[pic_background].w)
-        pic_w = size_.x;
+        pic.x = size_.x;
     else
-        pic_w = global::bmpArray[pic_background].w;
+        pic.x = global::bmpArray[pic_background].w;
 
     if(size_.y <= global::bmpArray[pic_background].h)
-        pic_h = size_.y;
+        pic.y = size_.y;
     else
-        pic_h = global::bmpArray[pic_background].h;
+        pic.y = global::bmpArray[pic_background].h;
 
-    while(pos_x + pic_w <= static_cast<unsigned>(Surf_Button->w))
+    while(pos.x + pic.x <= static_cast<unsigned>(Surf_Button->w))
     {
-        while(pos_y + pic_h <= static_cast<unsigned>(Surf_Button->h))
+        while(pos.y + pic.y <= static_cast<unsigned>(Surf_Button->h))
         {
-            CSurface::Draw(Surf_Button, global::bmpArray[pic_background].surface,
-                           Position(static_cast<int>(pos_x), static_cast<int>(pos_y)), Extent(0, 0),
-                           Extent(pic_w, pic_h));
-            pos_y += pic_h;
+            CSurface::Draw(Surf_Button, global::bmpArray[pic_background].surface, pos, Position(0, 0), pic);
+            pos.y += pic.y;
         }
 
-        if(pos_y < static_cast<unsigned>(Surf_Button->h))
-            CSurface::Draw(Surf_Button, global::bmpArray[pic_background].surface,
-                           Position(static_cast<int>(pos_x), static_cast<int>(pos_y)), Extent(0, 0),
-                           Extent(pic_w, static_cast<unsigned>(Surf_Button->h - pos_y)));
+        if(pos.y < Surf_Button->h)
+            CSurface::Draw(Surf_Button, global::bmpArray[pic_background].surface, pos, Position(0, 0),
+                           Extent(pic.x, static_cast<unsigned>(Surf_Button->h - pos.y)));
 
-        pos_y = 0;
-        pos_x += pic_w;
+        pos.y = 0;
+        pos.x += pic.x;
     }
 
-    if(pos_x < static_cast<unsigned>(Surf_Button->w))
+    if(pos.x < Surf_Button->w)
     {
-        while(pos_y + pic_h <= static_cast<unsigned>(Surf_Button->h))
+        while(pos.y + pic.y <= static_cast<unsigned>(Surf_Button->h))
         {
-            CSurface::Draw(Surf_Button, global::bmpArray[pic_background].surface,
-                           Position(static_cast<int>(pos_x), static_cast<int>(pos_y)), Extent(0, 0),
-                           Extent(static_cast<unsigned>(Surf_Button->w - pos_x), pic_h));
-            pos_y += pic_h;
+            CSurface::Draw(Surf_Button, global::bmpArray[pic_background].surface, pos, Position(0, 0),
+                           Extent(static_cast<unsigned>(Surf_Button->w - pos.x), pic.y));
+            pos.y += pic.y;
         }
 
-        if(pos_y < static_cast<unsigned>(Surf_Button->h))
+        if(pos.y < Surf_Button->h)
             CSurface::Draw(
-              Surf_Button, global::bmpArray[pic_background].surface,
-              Position(static_cast<int>(pos_x), static_cast<int>(pos_y)), Extent(0, 0),
-              Extent(static_cast<unsigned>(Surf_Button->w - pos_x), static_cast<unsigned>(Surf_Button->h - pos_y)));
+              Surf_Button, global::bmpArray[pic_background].surface, pos, Position(0, 0),
+              Extent(static_cast<unsigned>(Surf_Button->w - pos.x), static_cast<unsigned>(Surf_Button->h - pos.y)));
     }
 
     // draw partial black frame
@@ -204,62 +197,62 @@ bool CButton::render()
     {
         // black frame is left and up
         // draw vertical line
-        pos_x = 0;
+        pos.x = 0;
         for(unsigned y = 0; y < size_.y; y++)
-            CSurface::DrawPixel_RGB(Surf_Button, Position(pos_x, y), 0, 0, 0);
+            CSurface::DrawPixel_RGB(Surf_Button, Position(pos.x, y), 0, 0, 0);
 
         // draw vertical line
-        pos_x = 1;
+        pos.x = 1;
         for(unsigned y = 0; y < size_.y - 1; y++)
-            CSurface::DrawPixel_RGB(Surf_Button, Position(pos_x, y), 0, 0, 0);
+            CSurface::DrawPixel_RGB(Surf_Button, Position(pos.x, y), 0, 0, 0);
 
         // draw horizontal line
-        pos_y = 0;
+        pos.y = 0;
         for(unsigned x = 0; x < size_.x; x++)
-            CSurface::DrawPixel_RGB(Surf_Button, Position(x, pos_y), 0, 0, 0);
+            CSurface::DrawPixel_RGB(Surf_Button, Position(x, pos.y), 0, 0, 0);
 
         // draw horizontal line
-        pos_y = 1;
+        pos.y = 1;
         for(unsigned x = 0; x < size_.x - 1; x++)
-            CSurface::DrawPixel_RGB(Surf_Button, Position(x, pos_y), 0, 0, 0);
+            CSurface::DrawPixel_RGB(Surf_Button, Position(x, pos.y), 0, 0, 0);
     } else
     {
         // black frame is right and down
         // draw vertical line
-        pos_x = size_.x - 1;
+        pos.x = size_.x - 1;
         for(unsigned y = 0; y < size_.y; y++)
-            CSurface::DrawPixel_RGB(Surf_Button, Position(pos_x, y), 0, 0, 0);
+            CSurface::DrawPixel_RGB(Surf_Button, Position(pos.x, y), 0, 0, 0);
 
         // draw vertical line
-        pos_x = size_.x - 2;
+        pos.x = size_.x - 2;
         for(unsigned y = 1; y < size_.y; y++)
-            CSurface::DrawPixel_RGB(Surf_Button, Position(pos_x, y), 0, 0, 0);
+            CSurface::DrawPixel_RGB(Surf_Button, Position(pos.x, y), 0, 0, 0);
 
         // draw horizontal line
-        pos_y = size_.y - 1;
+        pos.y = size_.y - 1;
         for(unsigned x = 0; x < size_.x; x++)
-            CSurface::DrawPixel_RGB(Surf_Button, Position(x, pos_y), 0, 0, 0);
+            CSurface::DrawPixel_RGB(Surf_Button, Position(x, pos.y), 0, 0, 0);
 
         // draw horizontal line
-        pos_y = size_.y - 2;
+        pos.y = size_.y - 2;
         for(unsigned x = 1; x < size_.x; x++)
-            CSurface::DrawPixel_RGB(Surf_Button, Position(x, pos_y), 0, 0, 0);
+            CSurface::DrawPixel_RGB(Surf_Button, Position(x, pos.y), 0, 0, 0);
     }
 
     // draw the foreground --> at first the color (marked or unmarked) and then the picture or text
     if(size_.x <= global::bmpArray[pic_normal].w)
-        pic_w = size_.x;
+        pic.x = size_.x;
     else
-        pic_w = global::bmpArray[pic_normal].w;
+        pic.x = global::bmpArray[pic_normal].w;
 
     if(size_.y <= global::bmpArray[pic_normal].h)
-        pic_h = size_.y;
+        pic.y = size_.y;
     else
-        pic_h = global::bmpArray[pic_normal].h;
+        pic.y = global::bmpArray[pic_normal].h;
 
     // beware overdrawing the left and upper frame
-    pos_x = 2;
-    pos_y = 2;
+    pos.x = 2;
+    pos.y = 2;
 
     // decide if button lights or not
     if(marked && !clicked)
@@ -268,40 +261,35 @@ bool CButton::render()
         foreground = pic_normal;
 
     // '-2' follows a few times, this means: beware overdrawing the right and lower frame
-    while(pos_x + pic_w <= static_cast<unsigned>(Surf_Button->w - 2))
+    while(pos.x + pic.x <= static_cast<unsigned>(Surf_Button->w - 2))
     {
-        while(pos_y + pic_h <= static_cast<unsigned>(Surf_Button->h - 2))
+        while(pos.y + pic.y <= static_cast<unsigned>(Surf_Button->h - 2))
         {
-            CSurface::Draw(Surf_Button, global::bmpArray[foreground].surface,
-                           Position(static_cast<int>(pos_x), static_cast<int>(pos_y)), Extent(0, 0),
-                           Extent(pic_w, pic_h));
-            pos_y += pic_h;
+            CSurface::Draw(Surf_Button, global::bmpArray[foreground].surface, pos, Position(0, 0), pic);
+            pos.y += pic.y;
         }
 
-        if(pos_y + 2 < static_cast<unsigned>(Surf_Button->h))
-            CSurface::Draw(Surf_Button, global::bmpArray[foreground].surface,
-                           Position(static_cast<int>(pos_x), static_cast<int>(pos_y)), Extent(0, 0),
-                           Extent(pic_w, static_cast<unsigned>(Surf_Button->h - pos_y)));
+        if(pos.y + 2 < Surf_Button->h)
+            CSurface::Draw(Surf_Button, global::bmpArray[foreground].surface, pos, Position(0, 0),
+                           Extent(pic.x, static_cast<unsigned>(Surf_Button->h - pos.y)));
 
-        pos_y = 2;
-        pos_x += pic_w;
+        pos.y = 2;
+        pos.x += pic.x;
     }
 
-    if(pos_x + 2 < static_cast<unsigned>(Surf_Button->w))
+    if(pos.x + 2 < Surf_Button->w)
     {
-        while(pos_y + pic_h <= static_cast<unsigned>(Surf_Button->h - 2))
+        while(pos.y + pic.y <= static_cast<unsigned>(Surf_Button->h - 2))
         {
-            CSurface::Draw(Surf_Button, global::bmpArray[foreground].surface,
-                           Position(static_cast<int>(pos_x), static_cast<int>(pos_y)), Extent(0, 0),
-                           Extent(static_cast<unsigned>(Surf_Button->w - 2 - pos_x), pic_h));
-            pos_y += pic_h;
+            CSurface::Draw(Surf_Button, global::bmpArray[foreground].surface, pos, Position(0, 0),
+                           Extent(static_cast<unsigned>(Surf_Button->w - 2 - pos.x), pic.y));
+            pos.y += pic.y;
         }
 
-        if(pos_y + 2 < static_cast<unsigned>(Surf_Button->h))
-            CSurface::Draw(Surf_Button, global::bmpArray[foreground].surface,
-                           Position(static_cast<int>(pos_x), static_cast<int>(pos_y)), Extent(0, 0),
-                           Extent(static_cast<unsigned>(Surf_Button->w - 2 - pos_x),
-                                  static_cast<unsigned>(Surf_Button->h - 2 - pos_y)));
+        if(pos.y + 2 < Surf_Button->h)
+            CSurface::Draw(Surf_Button, global::bmpArray[foreground].surface, pos, Position(0, 0),
+                           Extent(static_cast<unsigned>(Surf_Button->w - 2 - pos.x),
+                                  static_cast<unsigned>(Surf_Button->h - 2 - pos.y)));
     }
 
     // positioning the picture or write text

--- a/CIO/CButton.cpp
+++ b/CIO/CButton.cpp
@@ -8,8 +8,8 @@
 #include "../globals.h"
 #include "CFont.h"
 
-CButton::CButton(void callback(int), int clickedParam, Point16 pos, Extent16 size, int color,
-                 const char* text, int button_picture)
+CButton::CButton(void callback(int), int clickedParam, Point16 pos, Extent16 size, int color, const char* text,
+                 int button_picture)
 {
     marked = false;
     clicked = false;
@@ -115,8 +115,8 @@ void CButton::setMouseData(const SDL_MouseButtonEvent& button)
     if(button.button == SDL_BUTTON_LEFT)
     {
         // if mouse button is pressed ON the button, set marked=true
-        if((button.state == SDL_PRESSED) && (button.x >= pos_.x) && (button.x < pos_.x + size_.x) && (button.y >= pos_.y)
-           && (button.y < pos_.y + size_.y))
+        if((button.state == SDL_PRESSED) && (button.x >= pos_.x) && (button.x < pos_.x + size_.x)
+           && (button.y >= pos_.y) && (button.y < pos_.y + size_.y))
         {
             marked = true;
             clicked = true;
@@ -310,8 +310,8 @@ bool CButton::render()
             button_text = "PIC";
         }
     } else if(button_text)
-        CFont::writeText(Surf_Button, button_text, Position((int)size_.x / 2, (int)((size_.y - 11) / 2)), FontSize::Medium, button_text_color,
-                         FontAlign::Middle);
+        CFont::writeText(Surf_Button, button_text, Position((int)size_.x / 2, (int)((size_.y - 11) / 2)),
+                         FontSize::Medium, button_text_color, FontAlign::Middle);
 
     return true;
 }

--- a/CIO/CButton.cpp
+++ b/CIO/CButton.cpp
@@ -8,15 +8,13 @@
 #include "../globals.h"
 #include "CFont.h"
 
-CButton::CButton(void callback(int), int clickedParam, Sint16 x, Sint16 y, Uint16 w, Uint16 h, int color,
+CButton::CButton(void callback(int), int clickedParam, Point16 pos, Extent16 size, int color,
                  const char* text, int button_picture)
 {
     marked = false;
     clicked = false;
-    this->x_ = x;
-    this->y_ = y;
-    this->w = w;
-    this->h = h;
+    this->pos_ = pos;
+    this->size_ = size;
     setColor(color);
     this->button_picture = button_picture;
     button_text = text;
@@ -93,7 +91,7 @@ void CButton::setColor(int color)
 void CButton::setMouseData(const SDL_MouseMotionEvent& motion)
 {
     // cursor is on the button (and mouse button not pressed while moving on the button)
-    if((motion.x >= x_) && (motion.x < x_ + w) && (motion.y >= y_) && (motion.y < y_ + h))
+    if((motion.x >= pos_.x) && (motion.x < pos_.x + size_.x) && (motion.y >= pos_.y) && (motion.y < pos_.y + size_.y))
     {
         if(motion.state == SDL_RELEASED)
         {
@@ -117,8 +115,8 @@ void CButton::setMouseData(const SDL_MouseButtonEvent& button)
     if(button.button == SDL_BUTTON_LEFT)
     {
         // if mouse button is pressed ON the button, set marked=true
-        if((button.state == SDL_PRESSED) && (button.x >= x_) && (button.x < x_ + w) && (button.y >= y_)
-           && (button.y < y_ + h))
+        if((button.state == SDL_PRESSED) && (button.x >= pos_.x) && (button.x < pos_.x + size_.x) && (button.y >= pos_.y)
+           && (button.y < pos_.y + size_.y))
         {
             marked = true;
             clicked = true;
@@ -151,18 +149,18 @@ bool CButton::render()
     // if we need a new surface
     if(!Surf_Button)
     {
-        if((Surf_Button = makeRGBSurface(w, h)) == nullptr)
+        if((Surf_Button = makeRGBSurface(size_.x, size_.y)) == nullptr)
             return false;
     }
 
     // at first completly fill the background (not the fastest way, but simplier)
-    if(w <= global::bmpArray[pic_background].w)
-        pic_w = w;
+    if(size_.x <= global::bmpArray[pic_background].w)
+        pic_w = size_.x;
     else
         pic_w = global::bmpArray[pic_background].w;
 
-    if(h <= global::bmpArray[pic_background].h)
-        pic_h = h;
+    if(size_.y <= global::bmpArray[pic_background].h)
+        pic_h = size_.y;
     else
         pic_h = global::bmpArray[pic_background].h;
 
@@ -202,55 +200,55 @@ bool CButton::render()
         // black frame is left and up
         // draw vertical line
         pos_x = 0;
-        for(int y = 0; y < h; y++)
+        for(int y = 0; y < size_.y; y++)
             CSurface::DrawPixel_RGB(Surf_Button, pos_x, y, 0, 0, 0);
 
         // draw vertical line
         pos_x = 1;
-        for(int y = 0; y < h - 1; y++)
+        for(int y = 0; y < size_.y - 1; y++)
             CSurface::DrawPixel_RGB(Surf_Button, pos_x, y, 0, 0, 0);
 
         // draw horizontal line
         pos_y = 0;
-        for(int x = 0; x < w; x++)
+        for(int x = 0; x < size_.x; x++)
             CSurface::DrawPixel_RGB(Surf_Button, x, pos_y, 0, 0, 0);
 
         // draw horizontal line
         pos_y = 1;
-        for(int x = 0; x < w - 1; x++)
+        for(int x = 0; x < size_.x - 1; x++)
             CSurface::DrawPixel_RGB(Surf_Button, x, pos_y, 0, 0, 0);
     } else
     {
         // black frame is right and down
         // draw vertical line
-        pos_x = w - 1;
-        for(int y = 0; y < h; y++)
+        pos_x = size_.x - 1;
+        for(int y = 0; y < size_.y; y++)
             CSurface::DrawPixel_RGB(Surf_Button, pos_x, y, 0, 0, 0);
 
         // draw vertical line
-        pos_x = w - 2;
-        for(int y = 1; y < h; y++)
+        pos_x = size_.x - 2;
+        for(int y = 1; y < size_.y; y++)
             CSurface::DrawPixel_RGB(Surf_Button, pos_x, y, 0, 0, 0);
 
         // draw horizontal line
-        pos_y = h - 1;
-        for(int x = 0; x < w; x++)
+        pos_y = size_.y - 1;
+        for(int x = 0; x < size_.x; x++)
             CSurface::DrawPixel_RGB(Surf_Button, x, pos_y, 0, 0, 0);
 
         // draw horizontal line
-        pos_y = h - 2;
-        for(int x = 1; x < w; x++)
+        pos_y = size_.y - 2;
+        for(int x = 1; x < size_.x; x++)
             CSurface::DrawPixel_RGB(Surf_Button, x, pos_y, 0, 0, 0);
     }
 
     // draw the foreground --> at first the color (marked or unmarked) and then the picture or text
-    if(w <= global::bmpArray[pic_normal].w)
-        pic_w = w;
+    if(size_.x <= global::bmpArray[pic_normal].w)
+        pic_w = size_.x;
     else
         pic_w = global::bmpArray[pic_normal].w;
 
-    if(h <= global::bmpArray[pic_normal].h)
-        pic_h = h;
+    if(size_.y <= global::bmpArray[pic_normal].h)
+        pic_h = size_.y;
     else
         pic_h = global::bmpArray[pic_normal].h;
 
@@ -312,7 +310,7 @@ bool CButton::render()
             button_text = "PIC";
         }
     } else if(button_text)
-        CFont::writeText(Surf_Button, button_text, (int)w / 2, (int)((h - 11) / 2), FontSize::Medium, button_text_color,
+        CFont::writeText(Surf_Button, button_text, Position((int)size_.x / 2, (int)((size_.y - 11) / 2)), FontSize::Medium, button_text_color,
                          FontAlign::Middle);
 
     return true;

--- a/CIO/CButton.cpp
+++ b/CIO/CButton.cpp
@@ -309,7 +309,7 @@ bool CButton::render()
             button_text = "PIC";
         }
     } else if(button_text)
-        CFont::writeText(Surf_Button, button_text, Position(static_cast<int>(size_.x) / 2, static_cast<int>(size_.y - 11) / 2),
+        CFont::writeText(Surf_Button, button_text, Position(size_.x / 2, (size_.y - 11) / 2),
                          FontSize::Medium, button_text_color, FontAlign::Middle);
 
     return true;

--- a/CIO/CButton.cpp
+++ b/CIO/CButton.cpp
@@ -115,7 +115,8 @@ void CButton::setMouseData(const SDL_MouseButtonEvent& button)
     if(button.button == SDL_BUTTON_LEFT)
     {
         // if mouse button is pressed ON the button, set marked=true
-        if((button.state == SDL_PRESSED) && IsPointInRect(Position(button.x, button.y), Rect(Position(pos_), Extent(size_))))
+        if((button.state == SDL_PRESSED)
+           && IsPointInRect(Position(button.x, button.y), Rect(Position(pos_), Extent(size_))))
         {
             marked = true;
             clicked = true;
@@ -309,8 +310,8 @@ bool CButton::render()
             button_text = "PIC";
         }
     } else if(button_text)
-        CFont::writeText(Surf_Button, button_text, Position(size_.x / 2, (size_.y - 11) / 2),
-                         FontSize::Medium, button_text_color, FontAlign::Middle);
+        CFont::writeText(Surf_Button, button_text, Position(size_.x / 2, (size_.y - 11) / 2), FontSize::Medium,
+                         button_text_color, FontAlign::Middle);
 
     return true;
 }

--- a/CIO/CButton.cpp
+++ b/CIO/CButton.cpp
@@ -7,14 +7,14 @@
 #include "../CSurface.h"
 #include "../globals.h"
 #include "CFont.h"
+#include "CollisionDetection.h"
 
 CButton::CButton(void callback(int), int clickedParam, Point16 pos, Extent16 size, int color, const char* text,
                  int button_picture)
+    : pos_(pos), size_(size)
 {
     marked = false;
     clicked = false;
-    this->pos_ = pos;
-    this->size_ = size;
     setColor(color);
     this->button_picture = button_picture;
     button_text = text;
@@ -91,7 +91,7 @@ void CButton::setColor(int color)
 void CButton::setMouseData(const SDL_MouseMotionEvent& motion)
 {
     // cursor is on the button (and mouse button not pressed while moving on the button)
-    if((motion.x >= pos_.x) && (motion.x < pos_.x + size_.x) && (motion.y >= pos_.y) && (motion.y < pos_.y + size_.y))
+    if(IsPointInRect(Position(motion.x, motion.y), Rect(Position(pos_), Extent(size_))))
     {
         if(motion.state == SDL_RELEASED)
         {
@@ -115,8 +115,7 @@ void CButton::setMouseData(const SDL_MouseButtonEvent& button)
     if(button.button == SDL_BUTTON_LEFT)
     {
         // if mouse button is pressed ON the button, set marked=true
-        if((button.state == SDL_PRESSED) && (button.x >= pos_.x) && (button.x < pos_.x + size_.x)
-           && (button.y >= pos_.y) && (button.y < pos_.y + size_.y))
+        if((button.state == SDL_PRESSED) && IsPointInRect(Position(button.x, button.y), Rect(Position(pos_), Extent(size_))))
         {
             marked = true;
             clicked = true;
@@ -310,7 +309,7 @@ bool CButton::render()
             button_text = "PIC";
         }
     } else if(button_text)
-        CFont::writeText(Surf_Button, button_text, Position((int)size_.x / 2, (int)((size_.y - 11) / 2)),
+        CFont::writeText(Surf_Button, button_text, Position(static_cast<int>(size_.x) / 2, static_cast<int>(size_.y - 11) / 2),
                          FontSize::Medium, button_text_color, FontAlign::Middle);
 
     return true;

--- a/CIO/CButton.h
+++ b/CIO/CButton.h
@@ -15,10 +15,8 @@ class CButton
 private:
     SdlSurface Surf_Button;
     bool needRender;
-    Sint16 x_;
-    Sint16 y_;
-    Uint16 w;
-    Uint16 h;
+    Point16 pos_;
+    Extent16 size_;
     int pic_normal;
     int pic_marked;
     int pic_background;
@@ -33,16 +31,16 @@ private:
     int motionLeaveParam;
 
 public:
-    CButton(void callback(int), int clickedParam, Sint16 x = 0, Sint16 y = 0, Uint16 w = 20, Uint16 h = 20,
+    CButton(void callback(int), int clickedParam, Point16 pos = {0, 0}, Extent16 size = {20, 20},
             int color = BUTTON_GREY, const char* text = nullptr, int button_picture = -1);
     // Access
-    int getX() const { return x_; };
-    int getY() const { return y_; };
-    Point16 getPos() const { return {x_, y_}; }
-    int getW() const { return w; };
-    int getH() const { return h; };
-    void setX(int x) { this->x_ = x; };
-    void setY(int y) { this->y_ = y; };
+    int getX() const { return pos_.x; };
+    int getY() const { return pos_.y; };
+    Point16 getPos() const { return pos_; }
+    int getW() const { return size_.x; };
+    int getH() const { return size_.y; };
+    void setX(int x) { pos_.x = x; };
+    void setY(int y) { pos_.y = y; };
     void setButtonPicture(int picture);
     void setButtonText(const char* text);
     void setMouseData(const SDL_MouseMotionEvent& motion);

--- a/CIO/CButton.h
+++ b/CIO/CButton.h
@@ -15,8 +15,8 @@ class CButton
 private:
     SdlSurface Surf_Button;
     bool needRender;
-    Point16 pos_;
-    Extent16 size_;
+    Position pos_;
+    Extent size_;
     int pic_normal;
     int pic_marked;
     int pic_background;
@@ -31,14 +31,13 @@ private:
     int motionLeaveParam;
 
 public:
-    CButton(void callback(int), int clickedParam, Point16 pos = {0, 0}, Extent16 size = {20, 20},
+    CButton(void callback(int), int clickedParam, Position pos = {0, 0}, Extent size = {20, 20},
             int color = BUTTON_GREY, const char* text = nullptr, int button_picture = -1);
     // Access
     int getX() const { return pos_.x; };
     int getY() const { return pos_.y; };
-    Point16 getPos() const { return pos_; }
-    int getW() const { return size_.x; };
-    int getH() const { return size_.y; };
+    const Position& getPos() const { return pos_; }
+    const Extent& getSize() const { return size_; };
     void setX(int x) { pos_.x = x; };
     void setY(int y) { pos_.y = y; };
     void setButtonPicture(int picture);

--- a/CIO/CControlContainer.cpp
+++ b/CIO/CControlContainer.cpp
@@ -87,8 +87,8 @@ bool CControlContainer::eraseElement(T& collection, const U* element)
     return false;
 }
 
-CButton* CControlContainer::addButton(void callback(int), int clickedParam, Point16 pos, Extent16 size,
-                                      int color, const char* text, int picture)
+CButton* CControlContainer::addButton(void callback(int), int clickedParam, Point16 pos, Extent16 size, int color,
+                                      const char* text, int picture)
 {
     pos = pos + borderBeginSize;
 

--- a/CIO/CControlContainer.cpp
+++ b/CIO/CControlContainer.cpp
@@ -87,13 +87,12 @@ bool CControlContainer::eraseElement(T& collection, const U* element)
     return false;
 }
 
-CButton* CControlContainer::addButton(void callback(int), int clickedParam, Uint16 x, Uint16 y, Uint16 w, Uint16 h,
+CButton* CControlContainer::addButton(void callback(int), int clickedParam, Point16 pos, Extent16 size,
                                       int color, const char* text, int picture)
 {
-    x += borderBeginSize.x;
-    y += borderBeginSize.y;
+    pos = pos + borderBeginSize;
 
-    buttons.emplace_back(std::make_unique<CButton>(callback, clickedParam, x, y, w, h, color, text, picture));
+    buttons.emplace_back(std::make_unique<CButton>(callback, clickedParam, pos, size, color, text, picture));
     needRender = true;
     return buttons.back().get();
 }
@@ -103,12 +102,11 @@ bool CControlContainer::delButton(CButton* ButtonToDelete)
     return eraseElement(buttons, ButtonToDelete);
 }
 
-CFont* CControlContainer::addText(std::string string, int x, int y, FontSize fontsize, FontColor color)
+CFont* CControlContainer::addText(std::string string, Point16 pos, FontSize fontsize, FontColor color)
 {
-    x += borderBeginSize.x;
-    y += borderBeginSize.y;
+    pos = pos + borderBeginSize;
 
-    texts.emplace_back(std::make_unique<CFont>(std::move(string), x, y, fontsize, color));
+    texts.emplace_back(std::make_unique<CFont>(std::move(string), pos, fontsize, color));
     needRender = true;
     return texts.back().get();
 }
@@ -118,12 +116,11 @@ bool CControlContainer::delText(CFont* TextToDelete)
     return eraseElement(texts, TextToDelete);
 }
 
-CPicture* CControlContainer::addPicture(void callback(int), int clickedParam, Uint16 x, Uint16 y, int picture)
+CPicture* CControlContainer::addPicture(void callback(int), int clickedParam, Point16 pos, int picture)
 {
-    x += borderBeginSize.x;
-    y += borderBeginSize.y;
+    pos = pos + borderBeginSize;
 
-    pictures.emplace_back(std::make_unique<CPicture>(callback, clickedParam, x, y, picture));
+    pictures.emplace_back(std::make_unique<CPicture>(callback, clickedParam, pos, picture));
     needRender = true;
     return pictures.back().get();
 }
@@ -133,15 +130,14 @@ bool CControlContainer::delPicture(CPicture* PictureToDelete)
     return eraseElement(pictures, PictureToDelete);
 }
 
-int CControlContainer::addStaticPicture(int x, int y, int picture)
+int CControlContainer::addStaticPicture(Point16 pos, int picture)
 {
     if(picture < 0)
         return -1;
-    Position pos{x, y};
-    pos += Position(borderBeginSize);
+    pos = pos + borderBeginSize;
 
     unsigned id = static_pictures.empty() ? 0u : static_pictures.back().id + 1u;
-    static_pictures.emplace_back(Picture{pos, picture, id});
+    static_pictures.emplace_back(Picture{Position(pos), picture, id});
     needRender = true;
     return id;
 }
@@ -161,14 +157,13 @@ bool CControlContainer::delStaticPicture(int picId)
     return false;
 }
 
-CTextfield* CControlContainer::addTextfield(Uint16 x, Uint16 y, Uint16 cols, Uint16 rows, FontSize fontsize,
+CTextfield* CControlContainer::addTextfield(Point16 pos, Uint16 cols, Uint16 rows, FontSize fontsize,
                                             FontColor text_color, int bg_color, bool button_style)
 {
-    x += borderBeginSize.x;
-    y += borderBeginSize.y;
+    pos = pos + borderBeginSize;
 
     textfields.emplace_back(
-      std::make_unique<CTextfield>(x, y, cols, rows, fontsize, text_color, bg_color, button_style));
+      std::make_unique<CTextfield>(pos, cols, rows, fontsize, text_color, bg_color, button_style));
     needRender = true;
     return textfields.back().get();
 }

--- a/CIO/CControlContainer.cpp
+++ b/CIO/CControlContainer.cpp
@@ -14,9 +14,9 @@
 #include "helpers/containerUtils.h"
 
 CControlContainer::CControlContainer(int pic_background)
-    : CControlContainer(pic_background, Extent16::all(0), Extent16::all(0))
+    : CControlContainer(pic_background, Extent::all(0), Extent::all(0))
 {}
-CControlContainer::CControlContainer(int pic_background, Extent16 borderBeginSize, Extent16 borderEndSize)
+CControlContainer::CControlContainer(int pic_background, Extent borderBeginSize, Extent borderEndSize)
     : borderBeginSize(borderBeginSize), borderEndSize(borderEndSize), pic_background(pic_background)
 {}
 
@@ -87,7 +87,7 @@ bool CControlContainer::eraseElement(T& collection, const U* element)
     return false;
 }
 
-CButton* CControlContainer::addButton(void callback(int), int clickedParam, Point16 pos, Extent16 size, int color,
+CButton* CControlContainer::addButton(void callback(int), int clickedParam, Position pos, Extent size, int color,
                                       const char* text, int picture)
 {
     pos = pos + borderBeginSize;
@@ -102,7 +102,7 @@ bool CControlContainer::delButton(CButton* ButtonToDelete)
     return eraseElement(buttons, ButtonToDelete);
 }
 
-CFont* CControlContainer::addText(std::string string, Point16 pos, FontSize fontsize, FontColor color)
+CFont* CControlContainer::addText(std::string string, Position pos, FontSize fontsize, FontColor color)
 {
     pos = pos + borderBeginSize;
 
@@ -116,7 +116,7 @@ bool CControlContainer::delText(CFont* TextToDelete)
     return eraseElement(texts, TextToDelete);
 }
 
-CPicture* CControlContainer::addPicture(void callback(int), int clickedParam, Point16 pos, int picture)
+CPicture* CControlContainer::addPicture(void callback(int), int clickedParam, Position pos, int picture)
 {
     pos = pos + borderBeginSize;
 
@@ -130,14 +130,14 @@ bool CControlContainer::delPicture(CPicture* PictureToDelete)
     return eraseElement(pictures, PictureToDelete);
 }
 
-int CControlContainer::addStaticPicture(Point16 pos, int picture)
+int CControlContainer::addStaticPicture(Position pos, int picture)
 {
     if(picture < 0)
         return -1;
     pos = pos + borderBeginSize;
 
     unsigned id = static_pictures.empty() ? 0u : static_pictures.back().id + 1u;
-    static_pictures.emplace_back(Picture{Position(pos), picture, id});
+    static_pictures.emplace_back(Picture{pos, picture, id});
     needRender = true;
     return id;
 }
@@ -157,7 +157,7 @@ bool CControlContainer::delStaticPicture(int picId)
     return false;
 }
 
-CTextfield* CControlContainer::addTextfield(Point16 pos, Uint16 cols, Uint16 rows, FontSize fontsize,
+CTextfield* CControlContainer::addTextfield(Position pos, Uint16 cols, Uint16 rows, FontSize fontsize,
                                             FontColor text_color, int bg_color, bool button_style)
 {
     pos = pos + borderBeginSize;
@@ -173,10 +173,10 @@ bool CControlContainer::delTextfield(CTextfield* TextfieldToDelete)
     return eraseElement(textfields, TextfieldToDelete);
 }
 
-CSelectBox* CControlContainer::addSelectBox(Point16 pos, Extent16 size, FontSize fontsize, FontColor text_color,
+CSelectBox* CControlContainer::addSelectBox(Position pos, Extent size, FontSize fontsize, FontColor text_color,
                                             int bg_color)
 {
-    pos += Point16(borderBeginSize);
+    pos += Position(borderBeginSize);
 
     selectboxes.emplace_back(std::make_unique<CSelectBox>(pos, size, fontsize, text_color, bg_color));
     needRender = true;
@@ -197,7 +197,7 @@ void CControlContainer::renderElements()
     for(const auto& textfield : textfields)
         CSurface::Draw(surface, textfield->getSurface(), textfield->getX(), textfield->getY());
     for(const auto& selectbox : selectboxes)
-        CSurface::Draw(surface, selectbox->getSurface(), Position(selectbox->getPos()));
+        CSurface::Draw(surface, selectbox->getSurface(), selectbox->getPos());
     for(const auto& button : buttons)
         CSurface::Draw(surface, button->getSurface(), button->getX(), button->getY());
     for(const auto& static_picture : static_pictures)

--- a/CIO/CControlContainer.h
+++ b/CIO/CControlContainer.h
@@ -28,7 +28,7 @@ private:
     };
 
     // if waste is true, the menu will be delete within the game loop
-    Extent16 borderBeginSize, borderEndSize; // Width and height of border at left/top and right/bottom
+    Extent borderBeginSize, borderEndSize; // Width and height of border at left/top and right/bottom
     bool waste = false;
     int pic_background;
     std::vector<std::unique_ptr<CButton>> buttons;
@@ -53,10 +53,10 @@ protected:
 
 public:
     CControlContainer(int pic_background);
-    CControlContainer(int pic_background, Extent16 borderBeginSize, Extent16 borderEndSize);
+    CControlContainer(int pic_background, Extent borderBeginSize, Extent borderEndSize);
     ~CControlContainer() noexcept;
     // Access
-    Extent16 getBorderSize() const { return borderBeginSize + borderEndSize; }
+    Extent getBorderSize() const { return borderBeginSize + borderEndSize; }
     void setBackgroundPicture(int pic_background);
     virtual void setMouseData(SDL_MouseMotionEvent motion);
     virtual void setMouseData(SDL_MouseButtonEvent button);
@@ -69,20 +69,20 @@ public:
     void setWaste() { waste = true; }
     bool isWaste() const { return waste; }
     // Methods
-    CButton* addButton(void callback(int), int clickedParam, Point16 pos = {0, 0}, Extent16 size = {20, 20},
+    CButton* addButton(void callback(int), int clickedParam, Position pos = {0, 0}, Extent size = {20, 20},
                        int color = BUTTON_GREY, const char* text = nullptr, int picture = -1);
     bool delButton(CButton* ButtonToDelete);
-    CFont* addText(std::string string, Point16 pos, FontSize fontsize, FontColor color = FontColor::Yellow);
+    CFont* addText(std::string string, Position pos, FontSize fontsize, FontColor color = FontColor::Yellow);
     bool delText(CFont* TextToDelete);
-    CPicture* addPicture(void callback(int), int clickedParam, Point16 pos, int picture);
+    CPicture* addPicture(void callback(int), int clickedParam, Position pos, int picture);
     bool delPicture(CPicture* PictureToDelete);
-    int addStaticPicture(Point16 pos, int picture);
+    int addStaticPicture(Position pos, int picture);
     bool delStaticPicture(int picId);
-    CTextfield* addTextfield(Point16 pos = {0, 0}, Uint16 cols = 10, Uint16 rows = 1,
+    CTextfield* addTextfield(Position pos = {0, 0}, Uint16 cols = 10, Uint16 rows = 1,
                              FontSize fontsize = FontSize::Large, FontColor text_color = FontColor::Yellow,
                              int bg_color = -1, bool button_style = false);
     bool delTextfield(CTextfield* TextfieldToDelete);
-    CSelectBox* addSelectBox(Point16 pos, Extent16 size, FontSize fontsize = FontSize::Large,
+    CSelectBox* addSelectBox(Position pos, Extent size, FontSize fontsize = FontSize::Large,
                              FontColor text_color = FontColor::Yellow, int bg_color = -1);
     bool delSelectBox(CSelectBox* SelectBoxToDelete);
 };

--- a/CIO/CControlContainer.h
+++ b/CIO/CControlContainer.h
@@ -69,16 +69,16 @@ public:
     void setWaste() { waste = true; }
     bool isWaste() const { return waste; }
     // Methods
-    CButton* addButton(void callback(int), int clickedParam, Uint16 x = 0, Uint16 y = 0, Uint16 w = 20, Uint16 h = 20,
+    CButton* addButton(void callback(int), int clickedParam, Point16 pos = {0, 0}, Extent16 size = {20, 20},
                        int color = BUTTON_GREY, const char* text = nullptr, int picture = -1);
     bool delButton(CButton* ButtonToDelete);
-    CFont* addText(std::string string, int x, int y, FontSize fontsize, FontColor color = FontColor::Yellow);
+    CFont* addText(std::string string, Point16 pos, FontSize fontsize, FontColor color = FontColor::Yellow);
     bool delText(CFont* TextToDelete);
-    CPicture* addPicture(void callback(int), int clickedParam, Uint16 x, Uint16 y, int picture);
+    CPicture* addPicture(void callback(int), int clickedParam, Point16 pos, int picture);
     bool delPicture(CPicture* PictureToDelete);
-    int addStaticPicture(int x, int y, int picture);
+    int addStaticPicture(Point16 pos, int picture);
     bool delStaticPicture(int picId);
-    CTextfield* addTextfield(Uint16 x = 0, Uint16 y = 0, Uint16 cols = 10, Uint16 rows = 1,
+    CTextfield* addTextfield(Point16 pos = {0, 0}, Uint16 cols = 10, Uint16 rows = 1,
                              FontSize fontsize = FontSize::Large, FontColor text_color = FontColor::Yellow,
                              int bg_color = -1, bool button_style = false);
     bool delTextfield(CTextfield* TextfieldToDelete);

--- a/CIO/CFile.cpp
+++ b/CIO/CFile.cpp
@@ -416,15 +416,15 @@ bool CFile::read_lbm(FILE* fp, const boost::filesystem::path& filepath)
     {
         // picture uncompressed
         // main loop for reading picture lines
-        for(int y = 0; y < bmpArray->h; y++)
+        for(Position pos{0, 0}; pos.y < bmpArray->h; pos.y++)
         {
             // loop for reading pixels of the actual picture line
-            for(int x = 0; x < bmpArray->w; x++)
+            for(pos.x = 0; pos.x < bmpArray->w; pos.x++)
             {
                 // read color value (1 Byte)
                 CHECK_READ(libendian::read(&color_value, 1, fp));
                 // draw
-                CSurface::DrawPixel_Color(bmpArray->surface.get(), x, y, (Uint32)color_value);
+                CSurface::DrawPixel_Color(bmpArray->surface.get(), pos, (Uint32)color_value);
             }
         }
 
@@ -433,12 +433,12 @@ bool CFile::read_lbm(FILE* fp, const boost::filesystem::path& filepath)
         // picture compressed
 
         // main loop for reading picture lines
-        for(int y = 0; y < bmpArray->h; y++)
+        for(Position pos{0, 0}; pos.y < bmpArray->h; pos.y++)
         {
             // loop for reading pixels of the actual picture line
             //(cause of a kind of RLE-Compression we cannot read the pixels sequentially)
             //'x' will be incremented WITHIN the loop
-            for(int x = 0; x < bmpArray->w;)
+            for(pos.x = 0; pos.x < bmpArray->w;)
             {
                 // read compression type
                 CHECK_READ(libendian::read(&ctype, 1, fp));
@@ -446,20 +446,20 @@ bool CFile::read_lbm(FILE* fp, const boost::filesystem::path& filepath)
                 if(ctype >= 0)
                 {
                     // following 'ctype + 1' pixels are uncompressed
-                    for(int k = 0; k < ctype + 1; k++, x++)
+                    for(int k = 0; k < ctype + 1; k++, pos.x++)
                     {
                         // read color value (1 Byte)
                         CHECK_READ(libendian::read(&color_value, 1, fp));
                         // draw
-                        CSurface::DrawPixel_Color(bmpArray->surface.get(), x, y, (Uint32)color_value);
+                        CSurface::DrawPixel_Color(bmpArray->surface.get(), pos, (Uint32)color_value);
                     }
                 } else if(ctype >= -127)
                 {
                     // draw the following byte '-ctype + 1' times to the surface
                     CHECK_READ(libendian::read(&color_value, 1, fp));
 
-                    for(int k = 0; k < -ctype + 1; k++, x++)
-                        CSurface::DrawPixel_Color(bmpArray->surface.get(), x, y, (Uint32)color_value);
+                    for(int k = 0; k < -ctype + 1; k++, pos.x++)
+                        CSurface::DrawPixel_Color(bmpArray->surface.get(), pos, (Uint32)color_value);
                 } else // if (ctype == -128)
                 {
                     // ignore
@@ -1006,8 +1006,8 @@ bool CFile::read_bob02(FILE* fp)
     starts = new Uint16[bmpArray->h];
 
     // read start addresses
-    for(int y = 0; y < bmpArray->h; y++)
-        CHECK_READ(libendian::le_read_us(&starts[y], fp));
+    for(Position pos{0, 0}; pos.y < bmpArray->h; pos.y++)
+        CHECK_READ(libendian::le_read_us(&starts[pos.y], fp));
 
     // now we are ready to read the picture lines and fill the surface, so lets create one
     if((bmpArray->surface = makePalSurface(bmpArray->w, bmpArray->h, palActual->colors)) == nullptr)
@@ -1016,35 +1016,35 @@ bool CFile::read_bob02(FILE* fp)
     // SDL_SetAlpha(bmpArray->surface, SDL_SRCALPHA, 128);
 
     // main loop for reading picture lines
-    for(int y = 0; y < bmpArray->h; y++)
+    for(Position pos{0, 0}; pos.y < bmpArray->h; pos.y++)
     {
         // set fp to the needed offset (where the picture line starts)
-        fseek(fp, starting_point + (Uint32)starts[y], SEEK_SET);
+        fseek(fp, starting_point + (Uint32)starts[pos.y], SEEK_SET);
 
         // loop for reading pixels of the actual picture line
         //(cause of a kind of RLE-Compression we cannot read the pixels sequentially)
         //'x' will be incremented WITHIN the loop
-        for(int x = 0; x < bmpArray->w;)
+        for(pos.x = 0; pos.x < bmpArray->w;)
         {
             // number of following colored pixels (1 Byte)
             CHECK_READ(libendian::read(&count_color, 1, fp));
 
             // loop for drawing the colored pixels to the surface
-            for(int k = 0; k < count_color; k++, x++)
+            for(int k = 0; k < count_color; k++, pos.x++)
             {
                 // read color value (1 Byte)
                 CHECK_READ(libendian::read(&color_value, 1, fp));
                 // draw
-                CSurface::DrawPixel_Color(bmpArray->surface.get(), x, y, (Uint32)color_value);
+                CSurface::DrawPixel_Color(bmpArray->surface.get(), pos, (Uint32)color_value);
             }
 
             // number of transparent pixels to draw now (1 Byte)
             CHECK_READ(libendian::read(&count_trans, 1, fp));
 
             // loop for drawing the transparent pixels to the surface
-            for(int k = 0; k < count_trans; k++, x++)
+            for(int k = 0; k < count_trans; k++, pos.x++)
             {
-                CSurface::DrawPixel_RGBA(bmpArray->surface.get(), x, y, 0, 0, 0, 0);
+                CSurface::DrawPixel_RGBA(bmpArray->surface.get(), pos, 0, 0, 0, 0);
             }
         }
 
@@ -1166,8 +1166,8 @@ bool CFile::read_bob04(FILE* fp, int player_color)
     starts = new Uint16[bmpArray->h];
 
     // read start addresses
-    for(int y = 0; y < bmpArray->h; y++)
-        CHECK_READ(libendian::le_read_us(&starts[y], fp));
+    for(Position pos{0, 0}; pos.y < bmpArray->h; pos.y++)
+        CHECK_READ(libendian::le_read_us(&starts[pos.y], fp));
 
     // now we are ready to read the picture lines and fill the surface, so lets create one
     if((bmpArray->surface = makePalSurface(bmpArray->w, bmpArray->h, palActual->colors)) == nullptr)
@@ -1176,48 +1176,48 @@ bool CFile::read_bob04(FILE* fp, int player_color)
     SDL_SetColorKey(bmpArray->surface.get(), SDL_TRUE, SDL_MapRGB(bmpArray->surface->format, 0, 0, 0));
 
     // main loop for reading picture lines
-    for(int y = 0; y < bmpArray->h; y++)
+    for(Position pos{0, 0}; pos.y < bmpArray->h; pos.y++)
     {
         // set fp to the needed offset (where the picture line starts)
-        fseek(fp, starting_point + (Uint32)starts[y], SEEK_SET);
+        fseek(fp, starting_point + (Uint32)starts[pos.y], SEEK_SET);
 
         // loop for reading pixels of the actual picture line
         //(cause of a kind of RLE-Compression we cannot read the pixels sequentially)
         //'x' will be incremented WITHIN the loop
-        for(int x = 0; x < bmpArray->w;)
+        for(pos.x = 0; pos.x < bmpArray->w;)
         {
             // read our 'shift' (1 Byte)
             CHECK_READ(libendian::read(&shift, 1, fp));
 
             if(shift < 0x41)
             {
-                for(int i = 1; i <= shift; i++, x++)
+                for(int i = 1; i <= shift; i++, pos.x++)
                 {
-                    CSurface::DrawPixel_RGBA(bmpArray->surface.get(), x, y, 0, 0, 0, 0);
+                    CSurface::DrawPixel_RGBA(bmpArray->surface.get(), pos, 0, 0, 0, 0);
                 }
             } else if(shift < 0x81)
             {
                 CHECK_READ(libendian::read(&color_value, 1, fp));
 
-                for(int i = 1; i <= shift - 0x40; i++, x++)
+                for(int i = 1; i <= shift - 0x40; i++, pos.x++)
                 {
-                    CSurface::DrawPixel_Color(bmpArray->surface.get(), x, y, /*0x80 - 0x40*/ +(Uint32)color_value);
+                    CSurface::DrawPixel_Color(bmpArray->surface.get(), pos, /*0x80 - 0x40*/ +(Uint32)color_value);
                 }
             } else if(shift < 0xC1)
             {
                 CHECK_READ(libendian::read(&color_value, 1, fp));
 
-                for(int i = 1; i <= shift - 0x80; i++, x++)
+                for(int i = 1; i <= shift - 0x80; i++, pos.x++)
                 {
-                    CSurface::DrawPixel_Color(bmpArray->surface.get(), x, y, player_color + (Uint32)color_value);
+                    CSurface::DrawPixel_Color(bmpArray->surface.get(), pos, player_color + (Uint32)color_value);
                 }
             } else // if (shift > 0xC0)
             {
                 CHECK_READ(libendian::read(&color_value, 1, fp));
 
-                for(int i = 1; i <= shift - 0xC0; i++, x++)
+                for(int i = 1; i <= shift - 0xC0; i++, pos.x++)
                 {
-                    CSurface::DrawPixel_Color(bmpArray->surface.get(), x, y, (Uint32)color_value);
+                    CSurface::DrawPixel_Color(bmpArray->surface.get(), pos, (Uint32)color_value);
                 }
             }
         }
@@ -1306,8 +1306,8 @@ bool CFile::read_bob07(FILE* fp)
     starts = new Uint16[shadowArray->h];
 
     // read start addresses
-    for(int y = 0; y < shadowArray->h; y++)
-        CHECK_READ(libendian::le_read_us(&starts[y], fp));
+    for(Position pos{0, 0}; pos.y < shadowArray->h; pos.y++)
+        CHECK_READ(libendian::le_read_us(&starts[pos.y], fp));
 
     // now we are ready to read the picture lines and fill the surface, so lets create one
     if((shadowArray->surface = makePalSurface(shadowArray->w, shadowArray->h, palActual->colors)) == nullptr)
@@ -1315,33 +1315,33 @@ bool CFile::read_bob07(FILE* fp)
     // SDL_SetAlpha(shadowArray->surface, SDL_SRCALPHA, 128);
 
     // main loop for reading picture lines
-    for(int y = 0; y < shadowArray->h; y++)
+    for(Position pos{0, 0}; pos.y < shadowArray->h; pos.y++)
     {
         // set fp to the needed offset (where the picture line starts)
-        fseek(fp, starting_point + (Uint32)starts[y], SEEK_SET);
+        fseek(fp, starting_point + (Uint32)starts[pos.y], SEEK_SET);
 
         // loop for reading pixels of the actual picture line
         //(cause of a kind of RLE-Compression we cannot read the pixels sequentially)
         //'x' will be incremented WITHIN the loop
-        for(int x = 0; x < shadowArray->w;)
+        for(pos.x = 0; pos.x < shadowArray->w;)
         {
             // number of half-transparent black (alpha value = 0x40) pixels (1 Byte)
             CHECK_READ(libendian::read(&count_black, 1, fp));
 
             // loop for drawing the black pixels to the surface
-            for(int k = 0; k < count_black; k++, x++)
+            for(int k = 0; k < count_black; k++, pos.x++)
             {
                 // draw
-                CSurface::DrawPixel_RGBA(shadowArray->surface.get(), x, y, 0, 0, 0, 0x40);
+                CSurface::DrawPixel_RGBA(shadowArray->surface.get(), pos, 0, 0, 0, 0x40);
             }
 
             // number of transparent pixels to draw now (1 Byte)
             CHECK_READ(libendian::read(&count_trans, 1, fp));
 
             // loop for drawing the transparent pixels to the surface
-            for(int k = 0; k < count_trans; k++, x++)
+            for(int k = 0; k < count_trans; k++, pos.x++)
             {
-                CSurface::DrawPixel_RGBA(shadowArray->surface.get(), x, y, 0, 0, 0, 0);
+                CSurface::DrawPixel_RGBA(shadowArray->surface.get(), pos, 0, 0, 0, 0);
             }
         }
 
@@ -1429,15 +1429,15 @@ bool CFile::read_bob14(FILE* fp)
     fseek(fp, data_start, SEEK_SET);
 
     // main loop for reading picture lines
-    for(int y = 0; y < bmpArray->h; y++)
+    for(Position pos{0, 0}; pos.y < bmpArray->h; pos.y++)
     {
         // loop for reading pixels of the actual picture line
-        for(int x = 0; x < bmpArray->w; x++)
+        for(pos.x = 0; pos.x < bmpArray->w; pos.x++)
         {
             // read color value (1 Byte)
             CHECK_READ(libendian::read(&color_value, 1, fp));
             // draw
-            CSurface::DrawPixel_Color(bmpArray->surface.get(), x, y, (Uint32)color_value);
+            CSurface::DrawPixel_Color(bmpArray->surface.get(), pos, (Uint32)color_value);
         }
     }
 

--- a/CIO/CFile.cpp
+++ b/CIO/CFile.cpp
@@ -1006,8 +1006,8 @@ bool CFile::read_bob02(FILE* fp)
     starts = new Uint16[bmpArray->h];
 
     // read start addresses
-    for(Position pos{0, 0}; pos.y < bmpArray->h; pos.y++)
-        CHECK_READ(libendian::le_read_us(&starts[pos.y], fp));
+    for(int y = 0; y < bmpArray->h; y++)
+        CHECK_READ(libendian::le_read_us(&starts[y], fp));
 
     // now we are ready to read the picture lines and fill the surface, so lets create one
     if((bmpArray->surface = makePalSurface(bmpArray->w, bmpArray->h, palActual->colors)) == nullptr)
@@ -1166,8 +1166,8 @@ bool CFile::read_bob04(FILE* fp, int player_color)
     starts = new Uint16[bmpArray->h];
 
     // read start addresses
-    for(Position pos{0, 0}; pos.y < bmpArray->h; pos.y++)
-        CHECK_READ(libendian::le_read_us(&starts[pos.y], fp));
+    for(int y = 0; y < bmpArray->h; y++)
+        CHECK_READ(libendian::le_read_us(&starts[y], fp));
 
     // now we are ready to read the picture lines and fill the surface, so lets create one
     if((bmpArray->surface = makePalSurface(bmpArray->w, bmpArray->h, palActual->colors)) == nullptr)
@@ -1306,8 +1306,8 @@ bool CFile::read_bob07(FILE* fp)
     starts = new Uint16[shadowArray->h];
 
     // read start addresses
-    for(Position pos{0, 0}; pos.y < shadowArray->h; pos.y++)
-        CHECK_READ(libendian::le_read_us(&starts[pos.y], fp));
+    for(int y = 0; y < shadowArray->h; y++)
+        CHECK_READ(libendian::le_read_us(&starts[y], fp));
 
     // now we are ready to read the picture lines and fill the surface, so lets create one
     if((shadowArray->surface = makePalSurface(shadowArray->w, shadowArray->h, palActual->colors)) == nullptr)

--- a/CIO/CFont.cpp
+++ b/CIO/CFont.cpp
@@ -8,8 +8,8 @@
 #include "../globals.h"
 #include <cassert>
 
-CFont::CFont(std::string text, unsigned x, unsigned y, FontSize fontsize, FontColor color)
-    : x_(x), y_(y), string_(std::move(text)), fontsize_(fontsize), color_(color), initialColor_(color), clickedParam(0)
+CFont::CFont(std::string text, Point16 pos, FontSize fontsize, FontColor color)
+    : x_(pos.x), y_(pos.y), string_(std::move(text)), fontsize_(fontsize), color_(color), initialColor_(color), clickedParam(0)
 {}
 
 void CFont::setPos(Position pos)

--- a/CIO/CFont.cpp
+++ b/CIO/CFont.cpp
@@ -8,7 +8,7 @@
 #include "../globals.h"
 #include <cassert>
 
-CFont::CFont(std::string text, Point16 pos, FontSize fontsize, FontColor color)
+CFont::CFont(std::string text, Position pos, FontSize fontsize, FontColor color)
     : x_(pos.x), y_(pos.y), string_(std::move(text)), fontsize_(fontsize), color_(color), initialColor_(color),
       clickedParam(0)
 {}

--- a/CIO/CFont.cpp
+++ b/CIO/CFont.cpp
@@ -9,7 +9,8 @@
 #include <cassert>
 
 CFont::CFont(std::string text, Point16 pos, FontSize fontsize, FontColor color)
-    : x_(pos.x), y_(pos.y), string_(std::move(text)), fontsize_(fontsize), color_(color), initialColor_(color), clickedParam(0)
+    : x_(pos.x), y_(pos.y), string_(std::move(text)), fontsize_(fontsize), color_(color), initialColor_(color),
+      clickedParam(0)
 {}
 
 void CFont::setPos(Position pos)

--- a/CIO/CFont.h
+++ b/CIO/CFont.h
@@ -17,8 +17,8 @@ class CFont
 
 private:
     SdlSurface Surf_Font;
-    Sint16 x_;
-    Sint16 y_;
+    int x_;
+    int y_;
     Uint16 w;
     Uint16 h;
     std::string string_;
@@ -30,7 +30,7 @@ private:
     void writeText();
 
 public:
-    CFont(std::string text, Point16 pos = {0, 0}, FontSize fontsize = FontSize::Small,
+    CFont(std::string text, Position pos = {0, 0}, FontSize fontsize = FontSize::Small,
           FontColor color = FontColor::Yellow);
     // Access
     int getX() const { return x_; };

--- a/CIO/CFont.h
+++ b/CIO/CFont.h
@@ -30,7 +30,7 @@ private:
     void writeText();
 
 public:
-    CFont(std::string text, unsigned x = 0, unsigned y = 0, FontSize fontsize = FontSize::Small,
+    CFont(std::string text, Point16 pos = {0, 0}, FontSize fontsize = FontSize::Small,
           FontColor color = FontColor::Yellow);
     // Access
     int getX() const { return x_; };
@@ -60,10 +60,10 @@ public:
     static bool writeText(SDL_Surface* Surf_Dest, const std::string& string, unsigned x = 0, unsigned y = 0,
                           FontSize fontsize = FontSize::Small, FontColor color = FontColor::Yellow,
                           FontAlign align = FontAlign::Left);
-    static bool writeText(SdlSurface& Surf_Dest, const std::string& string, unsigned x = 0, unsigned y = 0,
+    static bool writeText(SdlSurface& Surf_Dest, const std::string& string, Position pos,
                           FontSize fontsize = FontSize::Small, FontColor color = FontColor::Yellow,
                           FontAlign align = FontAlign::Left)
     {
-        return writeText(Surf_Dest.get(), string, x, y, fontsize, color, align);
+        return writeText(Surf_Dest.get(), string, pos.x, pos.y, fontsize, color, align);
     }
 };

--- a/CIO/CPicture.cpp
+++ b/CIO/CPicture.cpp
@@ -8,8 +8,7 @@
 #include "../globals.h"
 #include "CollisionDetection.h"
 
-CPicture::CPicture(void callback(int), int clickedParam, Point16 pos, int picture)
-    : pos_(pos)
+CPicture::CPicture(void callback(int), int clickedParam, Point16 pos, int picture) : pos_(pos)
 {
     marked = false;
     clicked = false;
@@ -53,7 +52,8 @@ void CPicture::setMouseData(const SDL_MouseButtonEvent& button)
     if(button.button == SDL_BUTTON_LEFT)
     {
         // if mouse button is pressed ON the button, set marked=true
-        if((button.state == SDL_PRESSED) && IsPointInRect(Position(button.x, button.y), Rect(Position(pos_), Extent(size_))))
+        if((button.state == SDL_PRESSED)
+           && IsPointInRect(Position(button.x, button.y), Rect(Position(pos_), Extent(size_))))
         {
             marked = true;
             clicked = true;

--- a/CIO/CPicture.cpp
+++ b/CIO/CPicture.cpp
@@ -52,8 +52,8 @@ void CPicture::setMouseData(const SDL_MouseButtonEvent& button)
     if(button.button == SDL_BUTTON_LEFT)
     {
         // if mouse button is pressed ON the button, set marked=true
-        if((button.state == SDL_PRESSED) && (button.x >= pos_.x) && (button.x < pos_.x + size_.x) && (button.y >= pos_.y)
-           && (button.y < pos_.y + size_.y))
+        if((button.state == SDL_PRESSED) && (button.x >= pos_.x) && (button.x < pos_.x + size_.x)
+           && (button.y >= pos_.y) && (button.y < pos_.y + size_.y))
         {
             marked = true;
             clicked = true;

--- a/CIO/CPicture.cpp
+++ b/CIO/CPicture.cpp
@@ -8,7 +8,7 @@
 #include "../globals.h"
 #include "CollisionDetection.h"
 
-CPicture::CPicture(void callback(int), int clickedParam, Point16 pos, int picture) : pos_(pos)
+CPicture::CPicture(void callback(int), int clickedParam, Position pos, int picture) : pos_(pos)
 {
     marked = false;
     clicked = false;
@@ -28,7 +28,7 @@ CPicture::CPicture(void callback(int), int clickedParam, Point16 pos, int pictur
 void CPicture::setMouseData(const SDL_MouseMotionEvent& motion)
 {
     // cursor is on the picture
-    if(IsPointInRect(Position(motion.x, motion.y), Rect(Position(pos_), Extent(size_))))
+    if(IsPointInRect(Position(motion.x, motion.y), Rect(pos_, size_)))
     {
         if(motion.state == SDL_RELEASED)
         {
@@ -52,8 +52,7 @@ void CPicture::setMouseData(const SDL_MouseButtonEvent& button)
     if(button.button == SDL_BUTTON_LEFT)
     {
         // if mouse button is pressed ON the button, set marked=true
-        if((button.state == SDL_PRESSED)
-           && IsPointInRect(Position(button.x, button.y), Rect(Position(pos_), Extent(size_))))
+        if((button.state == SDL_PRESSED) && IsPointInRect(Position(button.x, button.y), Rect(pos_, size_)))
         {
             marked = true;
             clicked = true;

--- a/CIO/CPicture.cpp
+++ b/CIO/CPicture.cpp
@@ -6,12 +6,13 @@
 #include "CPicture.h"
 #include "../CSurface.h"
 #include "../globals.h"
+#include "CollisionDetection.h"
 
 CPicture::CPicture(void callback(int), int clickedParam, Point16 pos, int picture)
+    : pos_(pos)
 {
     marked = false;
     clicked = false;
-    this->pos_ = pos;
     if(picture >= 0)
         this->picture_ = picture;
     else
@@ -28,7 +29,7 @@ CPicture::CPicture(void callback(int), int clickedParam, Point16 pos, int pictur
 void CPicture::setMouseData(const SDL_MouseMotionEvent& motion)
 {
     // cursor is on the picture
-    if((motion.x >= pos_.x) && (motion.x < pos_.x + size_.x) && (motion.y >= pos_.y) && (motion.y < pos_.y + size_.y))
+    if(IsPointInRect(Position(motion.x, motion.y), Rect(Position(pos_), Extent(size_))))
     {
         if(motion.state == SDL_RELEASED)
         {
@@ -52,8 +53,7 @@ void CPicture::setMouseData(const SDL_MouseButtonEvent& button)
     if(button.button == SDL_BUTTON_LEFT)
     {
         // if mouse button is pressed ON the button, set marked=true
-        if((button.state == SDL_PRESSED) && (button.x >= pos_.x) && (button.x < pos_.x + size_.x)
-           && (button.y >= pos_.y) && (button.y < pos_.y + size_.y))
+        if((button.state == SDL_PRESSED) && IsPointInRect(Position(button.x, button.y), Rect(Position(pos_), Extent(size_))))
         {
             marked = true;
             clicked = true;

--- a/CIO/CPicture.cpp
+++ b/CIO/CPicture.cpp
@@ -7,18 +7,17 @@
 #include "../CSurface.h"
 #include "../globals.h"
 
-CPicture::CPicture(void callback(int), int clickedParam, Uint16 x, Uint16 y, int picture)
+CPicture::CPicture(void callback(int), int clickedParam, Point16 pos, int picture)
 {
     marked = false;
     clicked = false;
-    this->x = x;
-    this->y = y;
+    this->pos_ = pos;
     if(picture >= 0)
         this->picture_ = picture;
     else
         this->picture_ = 0;
-    this->w = global::bmpArray[picture].w;
-    this->h = global::bmpArray[picture].h;
+    this->size_.x = global::bmpArray[picture].w;
+    this->size_.y = global::bmpArray[picture].h;
     this->callback = callback;
     this->clickedParam = clickedParam;
     motionEntryParam = -1;
@@ -29,7 +28,7 @@ CPicture::CPicture(void callback(int), int clickedParam, Uint16 x, Uint16 y, int
 void CPicture::setMouseData(const SDL_MouseMotionEvent& motion)
 {
     // cursor is on the picture
-    if((motion.x >= x) && (motion.x < x + w) && (motion.y >= y) && (motion.y < y + h))
+    if((motion.x >= pos_.x) && (motion.x < pos_.x + size_.x) && (motion.y >= pos_.y) && (motion.y < pos_.y + size_.y))
     {
         if(motion.state == SDL_RELEASED)
         {
@@ -53,8 +52,8 @@ void CPicture::setMouseData(const SDL_MouseButtonEvent& button)
     if(button.button == SDL_BUTTON_LEFT)
     {
         // if mouse button is pressed ON the button, set marked=true
-        if((button.state == SDL_PRESSED) && (button.x >= x) && (button.x < x + w) && (button.y >= y)
-           && (button.y < y + h))
+        if((button.state == SDL_PRESSED) && (button.x >= pos_.x) && (button.x < pos_.x + size_.x) && (button.y >= pos_.y)
+           && (button.y < pos_.y + size_.y))
         {
             marked = true;
             clicked = true;
@@ -78,7 +77,7 @@ bool CPicture::render()
     // if we need a new surface
     if(!Surf_Picture)
     {
-        Surf_Picture = makeRGBSurface(w, h);
+        Surf_Picture = makeRGBSurface(size_.x, size_.y);
         if(!Surf_Picture)
             return false;
         SDL_SetColorKey(Surf_Picture.get(), SDL_TRUE, SDL_MapRGB(Surf_Picture->format, 0, 0, 0));

--- a/CIO/CPicture.h
+++ b/CIO/CPicture.h
@@ -15,8 +15,8 @@ class CPicture
 private:
     SdlSurface Surf_Picture;
     bool needRender;
-    Point16 pos_;
-    Extent16 size_;
+    Position pos_;
+    Extent size_;
     int picture_;
     bool marked;
     bool clicked;
@@ -26,12 +26,11 @@ private:
     int motionLeaveParam;
 
 public:
-    CPicture(void callback(int), int clickedParam, Point16 pos = {0, 0}, int picture = -1);
+    CPicture(void callback(int), int clickedParam, Position pos = {0, 0}, int picture = -1);
     // Access
     int getX() const { return pos_.x; };
     int getY() const { return pos_.y; };
-    int getW() const { return size_.x; };
-    int getH() const { return size_.y; };
+    const Extent& getSize() const { return size_; };
     void setX(int x) { pos_.x = x; };
     void setY(int y) { pos_.y = y; };
     void setMouseData(const SDL_MouseMotionEvent& motion);

--- a/CIO/CPicture.h
+++ b/CIO/CPicture.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
+#include "Point.h"
 #include "SdlSurface.h"
-#include "defines.h"
 
 class CPicture
 {

--- a/CIO/CPicture.h
+++ b/CIO/CPicture.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "SdlSurface.h"
+#include "defines.h"
 
 class CPicture
 {
@@ -14,10 +15,8 @@ class CPicture
 private:
     SdlSurface Surf_Picture;
     bool needRender;
-    Uint16 x;
-    Uint16 y;
-    Uint16 w;
-    Uint16 h;
+    Point16 pos_;
+    Extent16 size_;
     int picture_;
     bool marked;
     bool clicked;
@@ -27,14 +26,14 @@ private:
     int motionLeaveParam;
 
 public:
-    CPicture(void callback(int), int clickedParam, Uint16 x = 0, Uint16 y = 0, int picture = -1);
+    CPicture(void callback(int), int clickedParam, Point16 pos = {0, 0}, int picture = -1);
     // Access
-    int getX() const { return x; };
-    int getY() const { return y; };
-    int getW() const { return w; };
-    int getH() const { return h; };
-    void setX(int x) { this->x = x; };
-    void setY(int y) { this->y = y; };
+    int getX() const { return pos_.x; };
+    int getY() const { return pos_.y; };
+    int getW() const { return size_.x; };
+    int getH() const { return size_.y; };
+    void setX(int x) { pos_.x = x; };
+    void setY(int y) { pos_.y = y; };
     void setMouseData(const SDL_MouseMotionEvent& motion);
     void setMouseData(const SDL_MouseButtonEvent& button);
     bool render();

--- a/CIO/CSelectBox.cpp
+++ b/CIO/CSelectBox.cpp
@@ -16,8 +16,8 @@ CSelectBox::CSelectBox(Point16 pos, Extent16 size, FontSize fontsize, FontColor 
 
     // button position is relative to the selectbox
     ScrollUpButton =
-      std::make_unique<CButton>(nullptr, 0, size_.x - 1 - 20, 0, 20, 20, BUTTON_GREY, nullptr, PICTURE_SMALL_ARROW_UP);
-    ScrollDownButton = std::make_unique<CButton>(nullptr, 0, size_.x - 1 - 20, size_.y - 1 - 20, 20, 20, BUTTON_GREY,
+      std::make_unique<CButton>(nullptr, 0, Point16(size_.x - 1 - 20, 0), Extent16(20, 20), BUTTON_GREY, nullptr, PICTURE_SMALL_ARROW_UP);
+    ScrollDownButton = std::make_unique<CButton>(nullptr, 0, Point16(size_.x - 1 - 20, size_.y - 1 - 20), Extent16(20, 20), BUTTON_GREY,
                                                  nullptr, PICTURE_SMALL_ARROW_DOWN);
 }
 
@@ -26,7 +26,7 @@ void CSelectBox::addOption(const std::string& string, std::function<void(int)> c
     // explanation: row_height = row_separator + fontsize
     const unsigned row_height = getLineHeight(fontsize);
 
-    auto Entry = std::make_unique<CFont>(string, 10, last_text_pos_y, fontsize, FontColor::Yellow);
+    auto Entry = std::make_unique<CFont>(string, Point16(10, last_text_pos_y), fontsize, FontColor::Yellow);
     Entry->setCallback(std::move(callback), param);
     Entries.emplace_back(std::move(Entry));
     last_text_pos_y += row_height;

--- a/CIO/CSelectBox.cpp
+++ b/CIO/CSelectBox.cpp
@@ -9,16 +9,17 @@
 #include "CButton.h"
 #include "CFont.h"
 
-CSelectBox::CSelectBox(Point16 pos, Extent16 size, FontSize fontsize, FontColor text_color, int bg_color)
+CSelectBox::CSelectBox(Position pos, Extent size, FontSize fontsize, FontColor text_color, int bg_color)
     : pos_(pos), size_(size), fontsize(fontsize), text_color(text_color)
 {
     setColor(bg_color);
 
     // button position is relative to the selectbox
-    ScrollUpButton = std::make_unique<CButton>(nullptr, 0, Point16(size_.x - 1 - 20, 0), Extent16(20, 20), BUTTON_GREY,
-                                               nullptr, PICTURE_SMALL_ARROW_UP);
-    ScrollDownButton = std::make_unique<CButton>(nullptr, 0, Point16(size_.x - 1 - 20, size_.y - 1 - 20),
-                                                 Extent16(20, 20), BUTTON_GREY, nullptr, PICTURE_SMALL_ARROW_DOWN);
+    ScrollUpButton = std::make_unique<CButton>(nullptr, 0, Position(static_cast<int>(size_.x) - 1 - 20, 0),
+                                               Extent(20, 20), BUTTON_GREY, nullptr, PICTURE_SMALL_ARROW_UP);
+    ScrollDownButton = std::make_unique<CButton>(
+      nullptr, 0, Position(static_cast<int>(size_.x) - 1 - 20, static_cast<int>(size_.y) - 1 - 20), Extent(20, 20),
+      BUTTON_GREY, nullptr, PICTURE_SMALL_ARROW_DOWN);
 }
 
 void CSelectBox::addOption(const std::string& string, std::function<void(int)> callback, int param)
@@ -26,7 +27,7 @@ void CSelectBox::addOption(const std::string& string, std::function<void(int)> c
     // explanation: row_height = row_separator + fontsize
     const unsigned row_height = getLineHeight(fontsize);
 
-    auto Entry = std::make_unique<CFont>(string, Point16(10, last_text_pos_y), fontsize, FontColor::Yellow);
+    auto Entry = std::make_unique<CFont>(string, Position(10, last_text_pos_y), fontsize, FontColor::Yellow);
     Entry->setCallback(std::move(callback), param);
     Entries.emplace_back(std::move(Entry));
     last_text_pos_y += row_height;
@@ -108,16 +109,17 @@ void CSelectBox::setMouseData(SDL_MouseButtonEvent button)
         // if mouse button is pressed ON the selectbox
         if(button.state == SDL_PRESSED)
         {
-            if((button.x >= pos_.x) && (button.x < pos_.x + size_.x) && (button.y >= pos_.y)
-               && (button.y < pos_.y + size_.y))
+            if((button.x >= pos_.x) && (button.x < pos_.x + static_cast<int>(size_.x)) && (button.y >= pos_.y)
+               && (button.y < pos_.y + static_cast<int>(size_.y)))
             {
                 // scroll up button
-                if((button.x > pos_.x + size_.x - 20) && (button.y < pos_.y + 20))
+                if((button.x > pos_.x + static_cast<int>(size_.x) - 20) && (button.y < pos_.y + 20))
                 {
                     scroll_up_button_marked = true;
                 }
                 // scroll down button
-                else if((button.x > pos_.x + size_.x - 20) && (button.y > pos_.y + size_.y - 20))
+                else if((button.x > pos_.x + static_cast<int>(size_.x) - 20)
+                        && (button.y > pos_.y + static_cast<int>(size_.y) - 20))
                 {
                     scroll_down_button_marked = true;
                 }
@@ -136,13 +138,13 @@ void CSelectBox::setMouseData(SDL_MouseButtonEvent button)
             }
         } else if(button.state == SDL_RELEASED)
         {
-            if((button.x >= pos_.x) && (button.x < pos_.x + size_.x) && (button.y >= pos_.y)
-               && (button.y < pos_.y + size_.y))
+            if((button.x >= pos_.x) && (button.x < pos_.x + static_cast<int>(size_.x)) && (button.y >= pos_.y)
+               && (button.y < pos_.y + static_cast<int>(size_.y)))
             {
                 // scroll up button
                 if(scroll_up_button_marked)
                 {
-                    if((button.x > pos_.x + size_.x - 20) && (button.y < pos_.y + 20))
+                    if((button.x > pos_.x + static_cast<int>(size_.x) - 20) && (button.y < pos_.y + 20))
                     {
                         // test if first entry is on the most upper position
                         if(!Entries.empty() && Entries.front()->getY() < 10)
@@ -157,10 +159,11 @@ void CSelectBox::setMouseData(SDL_MouseButtonEvent button)
                 // scroll down button
                 else if(scroll_down_button_marked)
                 {
-                    if((button.x > pos_.x + size_.x - 20) && (button.y > pos_.y + size_.y - 20))
+                    if((button.x > pos_.x + static_cast<int>(size_.x) - 20)
+                       && (button.y > pos_.y + static_cast<int>(size_.y) - 20))
                     {
                         // test if last entry is on the most lower position
-                        if(!Entries.empty() && Entries.back()->getY() > size_.y - 10)
+                        if(!Entries.empty() && Entries.back()->getY() > static_cast<int>(size_.y) - 10)
                         {
                             for(auto& entry : Entries)
                             {
@@ -203,11 +206,11 @@ void CSelectBox::setMouseData(SDL_MouseButtonEvent button)
 bool CSelectBox::render()
 {
     // position in the Surface 'Surf_Button'
-    Uint16 pos_x = 0;
-    Uint16 pos_y = 0;
+    unsigned pos_x = 0;
+    unsigned pos_y = 0;
     // width and height of the button color source picture
-    Uint16 pic_w = 0;
-    Uint16 pic_h = 0;
+    unsigned pic_w = 0;
+    unsigned pic_h = 0;
 
     // if we don't need to render, all is up to date, return true
     if(!needRender)
@@ -237,34 +240,37 @@ bool CSelectBox::render()
         else
             pic_h = global::bmpArray[pic].h;
 
-        while(pos_x + pic_w <= Surf_SelectBox->w)
+        while(pos_x + pic_w <= static_cast<unsigned>(Surf_SelectBox->w))
         {
-            while(pos_y + pic_h <= Surf_SelectBox->h)
+            while(pos_y + pic_h <= static_cast<unsigned>(Surf_SelectBox->h))
             {
-                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic].surface, pos_x, pos_y, 0, 0, pic_w, pic_h);
+                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic].surface,
+                               Position(static_cast<int>(pos_x), static_cast<int>(pos_y)), Extent(0, 0),
+                               Extent(pic_w, pic_h));
                 pos_y += pic_h;
             }
 
-            if(Surf_SelectBox->h - pos_y > 0)
-                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic].surface, pos_x, pos_y, 0, 0, pic_w,
-                               Surf_SelectBox->h - pos_y);
+            if(pos_y < static_cast<unsigned>(Surf_SelectBox->h))
+                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic].surface, static_cast<int>(pos_x),
+                               static_cast<int>(pos_y), 0, 0, pic_w, static_cast<unsigned>(Surf_SelectBox->h - pos_y));
 
             pos_y = 0;
             pos_x += pic_w;
         }
 
-        if(Surf_SelectBox->w - pos_x > 0)
+        if(pos_x < static_cast<unsigned>(Surf_SelectBox->w))
         {
-            while(pos_y + pic_h <= Surf_SelectBox->h)
+            while(pos_y + pic_h <= static_cast<unsigned>(Surf_SelectBox->h))
             {
-                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic].surface, pos_x, pos_y, 0, 0,
-                               Surf_SelectBox->w - pos_x, pic_h);
+                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic].surface, static_cast<int>(pos_x),
+                               static_cast<int>(pos_y), 0, 0, static_cast<unsigned>(Surf_SelectBox->w - pos_x), pic_h);
                 pos_y += pic_h;
             }
 
-            if(Surf_SelectBox->h - pos_y > 0)
-                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic].surface, pos_x, pos_y, 0, 0,
-                               Surf_SelectBox->w - pos_x, Surf_SelectBox->h - pos_y);
+            if(pos_y < static_cast<unsigned>(Surf_SelectBox->h))
+                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic].surface, static_cast<int>(pos_x),
+                               static_cast<int>(pos_y), 0, 0, static_cast<unsigned>(Surf_SelectBox->w - pos_x),
+                               static_cast<unsigned>(Surf_SelectBox->h - pos_y));
         }
     } else
         SDL_FillRect(Surf_SelectBox.get(), nullptr, SDL_MapRGB(Surf_SelectBox->format, 0, 0, 0));
@@ -274,8 +280,9 @@ bool CSelectBox::render()
         CSurface::Draw(Surf_SelectBox, entry->getSurface(), entry->getX(), entry->getY());
     }
 
-    CSurface::Draw(Surf_SelectBox, ScrollUpButton->getSurface(), size_.x - 1 - 20, 0);
-    CSurface::Draw(Surf_SelectBox, ScrollDownButton->getSurface(), size_.x - 1 - 20, size_.y - 1 - 20);
+    CSurface::Draw(Surf_SelectBox, ScrollUpButton->getSurface(), static_cast<int>(size_.x) - 1 - 20, 0);
+    CSurface::Draw(Surf_SelectBox, ScrollDownButton->getSurface(), static_cast<int>(size_.x) - 1 - 20,
+                   static_cast<int>(size_.y) - 1 - 20);
 
     rendered = true;
 

--- a/CIO/CSelectBox.cpp
+++ b/CIO/CSelectBox.cpp
@@ -205,12 +205,10 @@ void CSelectBox::setMouseData(SDL_MouseButtonEvent button)
 
 bool CSelectBox::render()
 {
-    // position in the Surface 'Surf_Button'
-    unsigned pos_x = 0;
-    unsigned pos_y = 0;
+    // position in the Surface 'Surf_SelectBox'
+    Position pos{0, 0};
     // width and height of the button color source picture
-    unsigned pic_w = 0;
-    unsigned pic_h = 0;
+    Extent pic{0, 0};
 
     // if we don't need to render, all is up to date, return true
     if(!needRender)
@@ -231,46 +229,44 @@ bool CSelectBox::render()
 
         // at first completly fill the background (not the fastest way, but simplier)
         if(size_.x <= global::bmpArray[pic].w)
-            pic_w = size_.x;
+            pic.x = size_.x;
         else
-            pic_w = global::bmpArray[pic].w;
+            pic.x = global::bmpArray[pic].w;
 
         if(size_.y <= global::bmpArray[pic].h)
-            pic_h = size_.y;
+            pic.y = size_.y;
         else
-            pic_h = global::bmpArray[pic].h;
+            pic.y = global::bmpArray[pic].h;
 
-        while(pos_x + pic_w <= static_cast<unsigned>(Surf_SelectBox->w))
+        while(pos.x + pic.x <= static_cast<unsigned>(Surf_SelectBox->w))
         {
-            while(pos_y + pic_h <= static_cast<unsigned>(Surf_SelectBox->h))
+            while(pos.y + pic.y <= static_cast<unsigned>(Surf_SelectBox->h))
             {
-                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic].surface,
-                               Position(static_cast<int>(pos_x), static_cast<int>(pos_y)), Extent(0, 0),
-                               Extent(pic_w, pic_h));
-                pos_y += pic_h;
+                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic].surface, pos, Position(0, 0), pic);
+                pos.y += pic.y;
             }
 
-            if(pos_y < static_cast<unsigned>(Surf_SelectBox->h))
-                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic].surface, static_cast<int>(pos_x),
-                               static_cast<int>(pos_y), 0, 0, pic_w, static_cast<unsigned>(Surf_SelectBox->h - pos_y));
+            if(pos.y < Surf_SelectBox->h)
+                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic].surface, pos.x, pos.y, 0, 0, pic.x,
+                               static_cast<unsigned>(Surf_SelectBox->h - pos.y));
 
-            pos_y = 0;
-            pos_x += pic_w;
+            pos.y = 0;
+            pos.x += pic.x;
         }
 
-        if(pos_x < static_cast<unsigned>(Surf_SelectBox->w))
+        if(pos.x < Surf_SelectBox->w)
         {
-            while(pos_y + pic_h <= static_cast<unsigned>(Surf_SelectBox->h))
+            while(pos.y + pic.y <= static_cast<unsigned>(Surf_SelectBox->h))
             {
-                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic].surface, static_cast<int>(pos_x),
-                               static_cast<int>(pos_y), 0, 0, static_cast<unsigned>(Surf_SelectBox->w - pos_x), pic_h);
-                pos_y += pic_h;
+                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic].surface, pos.x, pos.y, 0, 0,
+                               static_cast<unsigned>(Surf_SelectBox->w - pos.x), pic.y);
+                pos.y += pic.y;
             }
 
-            if(pos_y < static_cast<unsigned>(Surf_SelectBox->h))
-                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic].surface, static_cast<int>(pos_x),
-                               static_cast<int>(pos_y), 0, 0, static_cast<unsigned>(Surf_SelectBox->w - pos_x),
-                               static_cast<unsigned>(Surf_SelectBox->h - pos_y));
+            if(pos.y < Surf_SelectBox->h)
+                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic].surface, pos.x, pos.y, 0, 0,
+                               static_cast<unsigned>(Surf_SelectBox->w - pos.x),
+                               static_cast<unsigned>(Surf_SelectBox->h - pos.y));
         }
     } else
         SDL_FillRect(Surf_SelectBox.get(), nullptr, SDL_MapRGB(Surf_SelectBox->format, 0, 0, 0));

--- a/CIO/CSelectBox.cpp
+++ b/CIO/CSelectBox.cpp
@@ -15,10 +15,10 @@ CSelectBox::CSelectBox(Point16 pos, Extent16 size, FontSize fontsize, FontColor 
     setColor(bg_color);
 
     // button position is relative to the selectbox
-    ScrollUpButton =
-      std::make_unique<CButton>(nullptr, 0, Point16(size_.x - 1 - 20, 0), Extent16(20, 20), BUTTON_GREY, nullptr, PICTURE_SMALL_ARROW_UP);
-    ScrollDownButton = std::make_unique<CButton>(nullptr, 0, Point16(size_.x - 1 - 20, size_.y - 1 - 20), Extent16(20, 20), BUTTON_GREY,
-                                                 nullptr, PICTURE_SMALL_ARROW_DOWN);
+    ScrollUpButton = std::make_unique<CButton>(nullptr, 0, Point16(size_.x - 1 - 20, 0), Extent16(20, 20), BUTTON_GREY,
+                                               nullptr, PICTURE_SMALL_ARROW_UP);
+    ScrollDownButton = std::make_unique<CButton>(nullptr, 0, Point16(size_.x - 1 - 20, size_.y - 1 - 20),
+                                                 Extent16(20, 20), BUTTON_GREY, nullptr, PICTURE_SMALL_ARROW_DOWN);
 }
 
 void CSelectBox::addOption(const std::string& string, std::function<void(int)> callback, int param)

--- a/CIO/CSelectBox.cpp
+++ b/CIO/CSelectBox.cpp
@@ -224,30 +224,27 @@ bool CSelectBox::render()
     // draw the pictures for background and foreground or, if not set, fill with black color
     if(pic_background >= 0 && pic_foreground >= 0)
     {
-        int pic;
-        pic = pic_foreground;
-
         // at first completly fill the background (not the fastest way, but simplier)
-        if(size_.x <= global::bmpArray[pic].w)
+        if(size_.x <= global::bmpArray[pic_foreground].w)
             pic.x = size_.x;
         else
-            pic.x = global::bmpArray[pic].w;
+            pic.x = global::bmpArray[pic_foreground].w;
 
-        if(size_.y <= global::bmpArray[pic].h)
+        if(size_.y <= global::bmpArray[pic_foreground].h)
             pic.y = size_.y;
         else
-            pic.y = global::bmpArray[pic].h;
+            pic.y = global::bmpArray[pic_foreground].h;
 
         while(pos.x + pic.x <= static_cast<unsigned>(Surf_SelectBox->w))
         {
             while(pos.y + pic.y <= static_cast<unsigned>(Surf_SelectBox->h))
             {
-                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic].surface, pos, Position(0, 0), pic);
+                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic_foreground].surface, pos, Position(0, 0), pic);
                 pos.y += pic.y;
             }
 
             if(pos.y < Surf_SelectBox->h)
-                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic].surface, pos.x, pos.y, 0, 0, pic.x,
+                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic_foreground].surface, pos.x, pos.y, 0, 0, pic.x,
                                static_cast<unsigned>(Surf_SelectBox->h - pos.y));
 
             pos.y = 0;
@@ -258,13 +255,13 @@ bool CSelectBox::render()
         {
             while(pos.y + pic.y <= static_cast<unsigned>(Surf_SelectBox->h))
             {
-                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic].surface, pos.x, pos.y, 0, 0,
+                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic_foreground].surface, pos.x, pos.y, 0, 0,
                                static_cast<unsigned>(Surf_SelectBox->w - pos.x), pic.y);
                 pos.y += pic.y;
             }
 
             if(pos.y < Surf_SelectBox->h)
-                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic].surface, pos.x, pos.y, 0, 0,
+                CSurface::Draw(Surf_SelectBox, global::bmpArray[pic_foreground].surface, pos.x, pos.y, 0, 0,
                                static_cast<unsigned>(Surf_SelectBox->w - pos.x),
                                static_cast<unsigned>(Surf_SelectBox->h - pos.y));
         }

--- a/CIO/CSelectBox.h
+++ b/CIO/CSelectBox.h
@@ -21,8 +21,8 @@ class CSelectBox
 private:
     SdlSurface Surf_SelectBox;
     std::vector<std::unique_ptr<CFont>> Entries;
-    Point16 pos_;
-    Extent16 size_;
+    Position pos_;
+    Extent size_;
     FontSize fontsize;
     int pic_background;
     int pic_foreground;
@@ -35,10 +35,10 @@ private:
     bool needRender = true;
 
 public:
-    CSelectBox(Point16 pos, Extent16 size, FontSize fontsize = FontSize::Large,
-               FontColor text_color = FontColor::Yellow, int bg_color = -1);
-    const Point16& getPos() const { return pos_; }
-    const Extent16& getSize() const { return size_; }
+    CSelectBox(Position pos, Extent size, FontSize fontsize = FontSize::Large, FontColor text_color = FontColor::Yellow,
+               int bg_color = -1);
+    const Position& getPos() const { return pos_; }
+    const Extent& getSize() const { return size_; }
     bool hasRendered();
     void setMouseData(SDL_MouseButtonEvent button);
     void setMouseData(SDL_MouseMotionEvent motion);

--- a/CIO/CTextfield.cpp
+++ b/CIO/CTextfield.cpp
@@ -245,12 +245,10 @@ void CTextfield::setKeyboardData(const SDL_KeyboardEvent& key)
 
 bool CTextfield::render()
 {
-    // position in the Surface 'Surf_Button'
-    unsigned pos_x = 0;
-    unsigned pos_y = 0;
-    // width and height of the button color source picture
-    unsigned pic_w = 0;
-    unsigned pic_h = 0;
+    // position in the Surface 'Surf_Text'
+    Position pos{0, 0};
+    // width and height of the picture tile
+    Extent pic{0, 0};
     // we save the time to let a chiffre blink
     static Uint32 currentTime;
     static Uint32 lastTime = SDL_GetTicks();
@@ -292,46 +290,44 @@ bool CTextfield::render()
 
         // at first completly fill the background (not the fastest way, but simplier)
         if(size_.x <= global::bmpArray[pic].w)
-            pic_w = size_.x;
+            pic.x = size_.x;
         else
-            pic_w = global::bmpArray[pic].w;
+            pic.x = global::bmpArray[pic].w;
 
         if(size_.y <= global::bmpArray[pic].h)
-            pic_h = size_.y;
+            pic.y = size_.y;
         else
-            pic_h = global::bmpArray[pic].h;
+            pic.y = global::bmpArray[pic].h;
 
-        while(pos_x + pic_w <= static_cast<unsigned>(Surf_Text->w))
+        while(pos.x + pic.x <= static_cast<unsigned>(Surf_Text->w))
         {
-            while(pos_y + pic_h <= static_cast<unsigned>(Surf_Text->h))
+            while(pos.y + pic.y <= static_cast<unsigned>(Surf_Text->h))
             {
-                CSurface::Draw(Surf_Text, global::bmpArray[pic].surface,
-                               Position(static_cast<int>(pos_x), static_cast<int>(pos_y)), Extent(0, 0),
-                               Extent(pic_w, pic_h));
-                pos_y += pic_h;
+                CSurface::Draw(Surf_Text, global::bmpArray[pic].surface, pos, Position(0, 0), pic);
+                pos.y += pic.y;
             }
 
-            if(pos_y < static_cast<unsigned>(Surf_Text->h))
-                CSurface::Draw(Surf_Text, global::bmpArray[pic].surface, static_cast<int>(pos_x),
-                               static_cast<int>(pos_y), 0, 0, pic_w, static_cast<unsigned>(Surf_Text->h - pos_y));
+            if(pos.y < Surf_Text->h)
+                CSurface::Draw(Surf_Text, global::bmpArray[pic].surface, pos.x, pos.y, 0, 0, pic.x,
+                               static_cast<unsigned>(Surf_Text->h - pos.y));
 
-            pos_y = 0;
-            pos_x += pic_w;
+            pos.y = 0;
+            pos.x += pic.x;
         }
 
-        if(pos_x < static_cast<unsigned>(Surf_Text->w))
+        if(pos.x < Surf_Text->w)
         {
-            while(pos_y + pic_h <= static_cast<unsigned>(Surf_Text->h))
+            while(pos.y + pic.y <= static_cast<unsigned>(Surf_Text->h))
             {
-                CSurface::Draw(Surf_Text, global::bmpArray[pic].surface, static_cast<int>(pos_x),
-                               static_cast<int>(pos_y), 0, 0, static_cast<unsigned>(Surf_Text->w - pos_x), pic_h);
-                pos_y += pic_h;
+                CSurface::Draw(Surf_Text, global::bmpArray[pic].surface, pos.x, pos.y, 0, 0,
+                               static_cast<unsigned>(Surf_Text->w - pos.x), pic.y);
+                pos.y += pic.y;
             }
 
-            if(pos_y < static_cast<unsigned>(Surf_Text->h))
-                CSurface::Draw(Surf_Text, global::bmpArray[pic].surface, static_cast<int>(pos_x),
-                               static_cast<int>(pos_y), 0, 0, static_cast<unsigned>(Surf_Text->w - pos_x),
-                               static_cast<unsigned>(Surf_Text->h - pos_y));
+            if(pos.y < Surf_Text->h)
+                CSurface::Draw(Surf_Text, global::bmpArray[pic].surface, pos.x, pos.y, 0, 0,
+                               static_cast<unsigned>(Surf_Text->w - pos.x),
+                               static_cast<unsigned>(Surf_Text->h - pos.y));
         }
 
         // if not button_style, we are finished, otherwise continue drawing
@@ -342,96 +338,86 @@ bool CTextfield::render()
             {
                 // black frame is left and up
                 // draw vertical line
-                pos_x = 0;
                 for(unsigned y = 0; y < size_.y; y++)
-                    CSurface::DrawPixel_RGB(Surf_Text, Position(pos_x, y), 0, 0, 0);
+                    CSurface::DrawPixel_RGB(Surf_Text, Position(0, y), 0, 0, 0);
 
                 // draw vertical line
-                pos_x = 1;
                 for(unsigned y = 0; y < size_.y - 1; y++)
-                    CSurface::DrawPixel_RGB(Surf_Text, Position(pos_x, y), 0, 0, 0);
+                    CSurface::DrawPixel_RGB(Surf_Text, Position(1, y), 0, 0, 0);
 
                 // draw horizontal line
-                pos_y = 0;
                 for(unsigned x = 0; x < size_.x; x++)
-                    CSurface::DrawPixel_RGB(Surf_Text, Position(x, pos_y), 0, 0, 0);
+                    CSurface::DrawPixel_RGB(Surf_Text, Position(x, 0), 0, 0, 0);
 
                 // draw horizontal line
-                pos_y = 1;
                 for(unsigned x = 0; x < size_.x - 1; x++)
-                    CSurface::DrawPixel_RGB(Surf_Text, Position(x, pos_y), 0, 0, 0);
+                    CSurface::DrawPixel_RGB(Surf_Text, Position(x, 1), 0, 0, 0);
             } else
             {
                 // black frame is right and down
                 // draw vertical line
-                pos_x = size_.x - 1;
                 for(unsigned y = 0; y < size_.y; y++)
-                    CSurface::DrawPixel_RGB(Surf_Text, Position(pos_x, y), 0, 0, 0);
+                    CSurface::DrawPixel_RGB(Surf_Text, Position(size_.x - 1, y), 0, 0, 0);
 
                 // draw vertical line
-                pos_x = size_.x - 2;
                 for(unsigned y = 1; y < size_.y; y++)
-                    CSurface::DrawPixel_RGB(Surf_Text, Position(pos_x, y), 0, 0, 0);
+                    CSurface::DrawPixel_RGB(Surf_Text, Position(size_.x - 2, y), 0, 0, 0);
 
                 // draw horizontal line
-                pos_y = size_.y - 1;
                 for(unsigned x = 0; x < size_.x; x++)
-                    CSurface::DrawPixel_RGB(Surf_Text, Position(x, pos_y), 0, 0, 0);
+                    CSurface::DrawPixel_RGB(Surf_Text, Position(x, size_.y - 1), 0, 0, 0);
 
                 // draw horizontal line
-                pos_y = size_.y - 2;
                 for(unsigned x = 1; x < size_.x; x++)
-                    CSurface::DrawPixel_RGB(Surf_Text, Position(x, pos_y), 0, 0, 0);
+                    CSurface::DrawPixel_RGB(Surf_Text, Position(x, size_.y - 2), 0, 0, 0);
             }
 
             // draw the foreground --> at first the color (marked or unmarked) and then the picture or text
             if(size_.x <= global::bmpArray[pic_foreground].w)
-                pic_w = size_.x;
+                pic.x = size_.x;
             else
-                pic_w = global::bmpArray[pic_foreground].w;
+                pic.x = global::bmpArray[pic_foreground].w;
 
             if(size_.y <= global::bmpArray[pic_foreground].h)
-                pic_h = size_.y;
+                pic.y = size_.y;
             else
-                pic_h = global::bmpArray[pic_foreground].h;
+                pic.y = global::bmpArray[pic_foreground].h;
 
             // beware overdrawing the left and upper frame
-            pos_x = 2;
-            pos_y = 2;
+            pos.x = 2;
+            pos.y = 2;
 
             // '-2' follows a few times, this means: beware overdrawing the right and lower frame
-            while(pos_x + pic_w <= static_cast<unsigned>(Surf_Text->w - 2))
+            while(pos.x + pic.x <= static_cast<unsigned>(Surf_Text->w - 2))
             {
-                while(pos_y + pic_h <= static_cast<unsigned>(Surf_Text->h - 2))
+                while(pos.y + pic.y <= static_cast<unsigned>(Surf_Text->h - 2))
                 {
-                    CSurface::Draw(Surf_Text, global::bmpArray[pic_foreground].surface, static_cast<int>(pos_x),
-                                   static_cast<int>(pos_y), 0, 0, pic_w, pic_h);
-                    pos_y += pic_h;
+                    CSurface::Draw(Surf_Text, global::bmpArray[pic_foreground].surface, pos.x, pos.y, 0, 0, pic.x,
+                                   pic.y);
+                    pos.y += pic.y;
                 }
 
-                if(pos_y + 2 < static_cast<unsigned>(Surf_Text->h))
-                    CSurface::Draw(Surf_Text, global::bmpArray[pic_foreground].surface, static_cast<int>(pos_x),
-                                   static_cast<int>(pos_y), 0, 0, pic_w,
-                                   static_cast<unsigned>(Surf_Text->h - 2 - pos_y));
+                if(pos.y + 2 < Surf_Text->h)
+                    CSurface::Draw(Surf_Text, global::bmpArray[pic_foreground].surface, pos.x, pos.y, 0, 0, pic.x,
+                                   static_cast<unsigned>(Surf_Text->h - 2 - pos.y));
 
-                pos_y = 2;
-                pos_x += pic_w;
+                pos.y = 2;
+                pos.x += pic.x;
             }
 
-            if(pos_x + 2 < static_cast<unsigned>(Surf_Text->w))
+            if(pos.x + 2 < Surf_Text->w)
             {
-                while(pos_y + pic_h <= static_cast<unsigned>(Surf_Text->h - 2))
+                while(pos.y + pic.y <= static_cast<unsigned>(Surf_Text->h - 2))
                 {
-                    CSurface::Draw(Surf_Text, global::bmpArray[pic_foreground].surface, static_cast<int>(pos_x),
-                                   static_cast<int>(pos_y), 0, 0, static_cast<unsigned>(Surf_Text->w - 2 - pos_x),
-                                   pic_h);
-                    pos_y += pic_h;
+                    CSurface::Draw(Surf_Text, global::bmpArray[pic_foreground].surface, pos.x, pos.y, 0, 0,
+                                   static_cast<unsigned>(Surf_Text->w - 2 - pos.x), pic.y);
+                    pos.y += pic.y;
                 }
 
-                if(pos_y + 2 < static_cast<unsigned>(Surf_Text->h))
-                    CSurface::Draw(Surf_Text, global::bmpArray[pic_foreground].surface, static_cast<int>(pos_x),
-                                   static_cast<int>(pos_y), 0, 0, static_cast<unsigned>(Surf_Text->w - 2 - pos_x),
-                                   static_cast<unsigned>(Surf_Text->h - 2 - pos_y));
+                if(pos.y + 2 < Surf_Text->h)
+                    CSurface::Draw(Surf_Text, global::bmpArray[pic_foreground].surface, pos.x, pos.y, 0, 0,
+                                   static_cast<unsigned>(Surf_Text->w - 2 - pos.x),
+                                   static_cast<unsigned>(Surf_Text->h - 2 - pos.y));
             }
         }
     } else

--- a/CIO/CTextfield.cpp
+++ b/CIO/CTextfield.cpp
@@ -8,8 +8,8 @@
 #include "../globals.h"
 #include "CFont.h"
 
-CTextfield::CTextfield(Point16 pos, Uint16 cols, Uint16 rows, FontSize fontsize, FontColor text_color,
-                       int bg_color, bool button_style)
+CTextfield::CTextfield(Point16 pos, Uint16 cols, Uint16 rows, FontSize fontsize, FontColor text_color, int bg_color,
+                       bool button_style)
 {
     active = false;
     this->cols = (cols < 1 ? 1 : cols);
@@ -144,7 +144,8 @@ void CTextfield::setMouseData(SDL_MouseButtonEvent button)
         // if mouse button is pressed ON the textfield, set active=true
         if(button.state == SDL_PRESSED)
         {
-            active = (button.x >= getX()) && (button.x < getX() + size_.x) && (button.y >= getY()) && (button.y < getY() + size_.y);
+            active = (button.x >= getX()) && (button.x < getX() + size_.x) && (button.y >= getY())
+                     && (button.y < getY() + size_.y);
         }
     }
     needRender = true;

--- a/CIO/CTextfield.cpp
+++ b/CIO/CTextfield.cpp
@@ -9,7 +9,7 @@
 #include "CFont.h"
 #include "CollisionDetection.h"
 
-CTextfield::CTextfield(Point16 pos, Uint16 cols, Uint16 rows, FontSize fontsize, FontColor text_color, int bg_color,
+CTextfield::CTextfield(Position pos, Uint16 cols, Uint16 rows, FontSize fontsize, FontColor text_color, int bg_color,
                        bool button_style)
 {
     active = false;
@@ -145,7 +145,7 @@ void CTextfield::setMouseData(SDL_MouseButtonEvent button)
         // if mouse button is pressed ON the textfield, set active=true
         if(button.state == SDL_PRESSED)
         {
-            active = IsPointInRect(Position(button.x, button.y), Rect(Position(getX(), getY()), Extent(size_)));
+            active = IsPointInRect(Position(button.x, button.y), Rect(Position(getX(), getY()), size_));
         }
     }
     needRender = true;
@@ -246,11 +246,11 @@ void CTextfield::setKeyboardData(const SDL_KeyboardEvent& key)
 bool CTextfield::render()
 {
     // position in the Surface 'Surf_Button'
-    Uint16 pos_x = 0;
-    Uint16 pos_y = 0;
+    unsigned pos_x = 0;
+    unsigned pos_y = 0;
     // width and height of the button color source picture
-    Uint16 pic_w = 0;
-    Uint16 pic_h = 0;
+    unsigned pic_w = 0;
+    unsigned pic_h = 0;
     // we save the time to let a chiffre blink
     static Uint32 currentTime;
     static Uint32 lastTime = SDL_GetTicks();
@@ -301,34 +301,37 @@ bool CTextfield::render()
         else
             pic_h = global::bmpArray[pic].h;
 
-        while(pos_x + pic_w <= Surf_Text->w)
+        while(pos_x + pic_w <= static_cast<unsigned>(Surf_Text->w))
         {
-            while(pos_y + pic_h <= Surf_Text->h)
+            while(pos_y + pic_h <= static_cast<unsigned>(Surf_Text->h))
             {
-                CSurface::Draw(Surf_Text, global::bmpArray[pic].surface, pos_x, pos_y, 0, 0, pic_w, pic_h);
+                CSurface::Draw(Surf_Text, global::bmpArray[pic].surface,
+                               Position(static_cast<int>(pos_x), static_cast<int>(pos_y)), Extent(0, 0),
+                               Extent(pic_w, pic_h));
                 pos_y += pic_h;
             }
 
-            if(Surf_Text->h - pos_y > 0)
-                CSurface::Draw(Surf_Text, global::bmpArray[pic].surface, pos_x, pos_y, 0, 0, pic_w,
-                               Surf_Text->h - pos_y);
+            if(pos_y < static_cast<unsigned>(Surf_Text->h))
+                CSurface::Draw(Surf_Text, global::bmpArray[pic].surface, static_cast<int>(pos_x),
+                               static_cast<int>(pos_y), 0, 0, pic_w, static_cast<unsigned>(Surf_Text->h - pos_y));
 
             pos_y = 0;
             pos_x += pic_w;
         }
 
-        if(Surf_Text->w - pos_x > 0)
+        if(pos_x < static_cast<unsigned>(Surf_Text->w))
         {
-            while(pos_y + pic_h <= Surf_Text->h)
+            while(pos_y + pic_h <= static_cast<unsigned>(Surf_Text->h))
             {
-                CSurface::Draw(Surf_Text, global::bmpArray[pic].surface, pos_x, pos_y, 0, 0, Surf_Text->w - pos_x,
-                               pic_h);
+                CSurface::Draw(Surf_Text, global::bmpArray[pic].surface, static_cast<int>(pos_x),
+                               static_cast<int>(pos_y), 0, 0, static_cast<unsigned>(Surf_Text->w - pos_x), pic_h);
                 pos_y += pic_h;
             }
 
-            if(Surf_Text->h - pos_y > 0)
-                CSurface::Draw(Surf_Text, global::bmpArray[pic].surface, pos_x, pos_y, 0, 0, Surf_Text->w - pos_x,
-                               Surf_Text->h - pos_y);
+            if(pos_y < static_cast<unsigned>(Surf_Text->h))
+                CSurface::Draw(Surf_Text, global::bmpArray[pic].surface, static_cast<int>(pos_x),
+                               static_cast<int>(pos_y), 0, 0, static_cast<unsigned>(Surf_Text->w - pos_x),
+                               static_cast<unsigned>(Surf_Text->h - pos_y));
         }
 
         // if not button_style, we are finished, otherwise continue drawing
@@ -340,45 +343,45 @@ bool CTextfield::render()
                 // black frame is left and up
                 // draw vertical line
                 pos_x = 0;
-                for(int y = 0; y < size_.y; y++)
-                    CSurface::DrawPixel_RGB(Surf_Text, pos_x, y, 0, 0, 0);
+                for(unsigned y = 0; y < size_.y; y++)
+                    CSurface::DrawPixel_RGB(Surf_Text, Position(pos_x, y), 0, 0, 0);
 
                 // draw vertical line
                 pos_x = 1;
-                for(int y = 0; y < size_.y - 1; y++)
-                    CSurface::DrawPixel_RGB(Surf_Text, pos_x, y, 0, 0, 0);
+                for(unsigned y = 0; y < size_.y - 1; y++)
+                    CSurface::DrawPixel_RGB(Surf_Text, Position(pos_x, y), 0, 0, 0);
 
                 // draw horizontal line
                 pos_y = 0;
-                for(int x = 0; x < size_.x; x++)
-                    CSurface::DrawPixel_RGB(Surf_Text, x, pos_y, 0, 0, 0);
+                for(unsigned x = 0; x < size_.x; x++)
+                    CSurface::DrawPixel_RGB(Surf_Text, Position(x, pos_y), 0, 0, 0);
 
                 // draw horizontal line
                 pos_y = 1;
-                for(int x = 0; x < size_.x - 1; x++)
-                    CSurface::DrawPixel_RGB(Surf_Text, x, pos_y, 0, 0, 0);
+                for(unsigned x = 0; x < size_.x - 1; x++)
+                    CSurface::DrawPixel_RGB(Surf_Text, Position(x, pos_y), 0, 0, 0);
             } else
             {
                 // black frame is right and down
                 // draw vertical line
                 pos_x = size_.x - 1;
-                for(int y = 0; y < size_.y; y++)
-                    CSurface::DrawPixel_RGB(Surf_Text, pos_x, y, 0, 0, 0);
+                for(unsigned y = 0; y < size_.y; y++)
+                    CSurface::DrawPixel_RGB(Surf_Text, Position(pos_x, y), 0, 0, 0);
 
                 // draw vertical line
                 pos_x = size_.x - 2;
-                for(int y = 1; y < size_.y; y++)
-                    CSurface::DrawPixel_RGB(Surf_Text, pos_x, y, 0, 0, 0);
+                for(unsigned y = 1; y < size_.y; y++)
+                    CSurface::DrawPixel_RGB(Surf_Text, Position(pos_x, y), 0, 0, 0);
 
                 // draw horizontal line
                 pos_y = size_.y - 1;
-                for(int x = 0; x < size_.x; x++)
-                    CSurface::DrawPixel_RGB(Surf_Text, x, pos_y, 0, 0, 0);
+                for(unsigned x = 0; x < size_.x; x++)
+                    CSurface::DrawPixel_RGB(Surf_Text, Position(x, pos_y), 0, 0, 0);
 
                 // draw horizontal line
                 pos_y = size_.y - 2;
-                for(int x = 1; x < size_.x; x++)
-                    CSurface::DrawPixel_RGB(Surf_Text, x, pos_y, 0, 0, 0);
+                for(unsigned x = 1; x < size_.x; x++)
+                    CSurface::DrawPixel_RGB(Surf_Text, Position(x, pos_y), 0, 0, 0);
             }
 
             // draw the foreground --> at first the color (marked or unmarked) and then the picture or text
@@ -397,35 +400,38 @@ bool CTextfield::render()
             pos_y = 2;
 
             // '-2' follows a few times, this means: beware overdrawing the right and lower frame
-            while(pos_x + pic_w <= Surf_Text->w - 2)
+            while(pos_x + pic_w <= static_cast<unsigned>(Surf_Text->w - 2))
             {
-                while(pos_y + pic_h <= Surf_Text->h - 2)
+                while(pos_y + pic_h <= static_cast<unsigned>(Surf_Text->h - 2))
                 {
-                    CSurface::Draw(Surf_Text, global::bmpArray[pic_foreground].surface, pos_x, pos_y, 0, 0, pic_w,
-                                   pic_h);
+                    CSurface::Draw(Surf_Text, global::bmpArray[pic_foreground].surface, static_cast<int>(pos_x),
+                                   static_cast<int>(pos_y), 0, 0, pic_w, pic_h);
                     pos_y += pic_h;
                 }
 
-                if(Surf_Text->h - 2 - pos_y > 0)
-                    CSurface::Draw(Surf_Text, global::bmpArray[pic_foreground].surface, pos_x, pos_y, 0, 0, pic_w,
-                                   Surf_Text->h - 2 - pos_y);
+                if(pos_y + 2 < static_cast<unsigned>(Surf_Text->h))
+                    CSurface::Draw(Surf_Text, global::bmpArray[pic_foreground].surface, static_cast<int>(pos_x),
+                                   static_cast<int>(pos_y), 0, 0, pic_w,
+                                   static_cast<unsigned>(Surf_Text->h - 2 - pos_y));
 
                 pos_y = 2;
                 pos_x += pic_w;
             }
 
-            if(Surf_Text->w - 2 - pos_x > 0)
+            if(pos_x + 2 < static_cast<unsigned>(Surf_Text->w))
             {
-                while(pos_y + pic_h <= Surf_Text->h - 2)
+                while(pos_y + pic_h <= static_cast<unsigned>(Surf_Text->h - 2))
                 {
-                    CSurface::Draw(Surf_Text, global::bmpArray[pic_foreground].surface, pos_x, pos_y, 0, 0,
-                                   Surf_Text->w - 2 - pos_x, pic_h);
+                    CSurface::Draw(Surf_Text, global::bmpArray[pic_foreground].surface, static_cast<int>(pos_x),
+                                   static_cast<int>(pos_y), 0, 0, static_cast<unsigned>(Surf_Text->w - 2 - pos_x),
+                                   pic_h);
                     pos_y += pic_h;
                 }
 
-                if(Surf_Text->h - 2 - pos_y > 0)
-                    CSurface::Draw(Surf_Text, global::bmpArray[pic_foreground].surface, pos_x, pos_y, 0, 0,
-                                   Surf_Text->w - 2 - pos_x, Surf_Text->h - 2 - pos_y);
+                if(pos_y + 2 < static_cast<unsigned>(Surf_Text->h))
+                    CSurface::Draw(Surf_Text, global::bmpArray[pic_foreground].surface, static_cast<int>(pos_x),
+                                   static_cast<int>(pos_y), 0, 0, static_cast<unsigned>(Surf_Text->w - 2 - pos_x),
+                                   static_cast<unsigned>(Surf_Text->h - 2 - pos_y));
             }
         }
     } else

--- a/CIO/CTextfield.cpp
+++ b/CIO/CTextfield.cpp
@@ -282,33 +282,29 @@ bool CTextfield::render()
     if(pic_background >= 0 && pic_foreground >= 0)
     {
         // in case the textfield should look like a button, we do it, otherwise we use pic_foreground for the background
-        int pic;
-        if(button_style)
-            pic = pic_background;
-        else
-            pic = pic_foreground;
+        const int bmpIdx = button_style ? pic_background : pic_foreground;
 
         // at first completly fill the background (not the fastest way, but simplier)
-        if(size_.x <= global::bmpArray[pic].w)
+        if(size_.x <= global::bmpArray[bmpIdx].w)
             pic.x = size_.x;
         else
-            pic.x = global::bmpArray[pic].w;
+            pic.x = global::bmpArray[bmpIdx].w;
 
-        if(size_.y <= global::bmpArray[pic].h)
+        if(size_.y <= global::bmpArray[bmpIdx].h)
             pic.y = size_.y;
         else
-            pic.y = global::bmpArray[pic].h;
+            pic.y = global::bmpArray[bmpIdx].h;
 
         while(pos.x + pic.x <= static_cast<unsigned>(Surf_Text->w))
         {
             while(pos.y + pic.y <= static_cast<unsigned>(Surf_Text->h))
             {
-                CSurface::Draw(Surf_Text, global::bmpArray[pic].surface, pos, Position(0, 0), pic);
+                CSurface::Draw(Surf_Text, global::bmpArray[bmpIdx].surface, pos, Position(0, 0), pic);
                 pos.y += pic.y;
             }
 
             if(pos.y < Surf_Text->h)
-                CSurface::Draw(Surf_Text, global::bmpArray[pic].surface, pos.x, pos.y, 0, 0, pic.x,
+                CSurface::Draw(Surf_Text, global::bmpArray[bmpIdx].surface, pos.x, pos.y, 0, 0, pic.x,
                                static_cast<unsigned>(Surf_Text->h - pos.y));
 
             pos.y = 0;
@@ -319,13 +315,13 @@ bool CTextfield::render()
         {
             while(pos.y + pic.y <= static_cast<unsigned>(Surf_Text->h))
             {
-                CSurface::Draw(Surf_Text, global::bmpArray[pic].surface, pos.x, pos.y, 0, 0,
+                CSurface::Draw(Surf_Text, global::bmpArray[bmpIdx].surface, pos.x, pos.y, 0, 0,
                                static_cast<unsigned>(Surf_Text->w - pos.x), pic.y);
                 pos.y += pic.y;
             }
 
             if(pos.y < Surf_Text->h)
-                CSurface::Draw(Surf_Text, global::bmpArray[pic].surface, pos.x, pos.y, 0, 0,
+                CSurface::Draw(Surf_Text, global::bmpArray[bmpIdx].surface, pos.x, pos.y, 0, 0,
                                static_cast<unsigned>(Surf_Text->w - pos.x),
                                static_cast<unsigned>(Surf_Text->h - pos.y));
         }

--- a/CIO/CTextfield.cpp
+++ b/CIO/CTextfield.cpp
@@ -7,6 +7,7 @@
 #include "../CSurface.h"
 #include "../globals.h"
 #include "CFont.h"
+#include "CollisionDetection.h"
 
 CTextfield::CTextfield(Point16 pos, Uint16 cols, Uint16 rows, FontSize fontsize, FontColor text_color, int bg_color,
                        bool button_style)
@@ -144,8 +145,7 @@ void CTextfield::setMouseData(SDL_MouseButtonEvent button)
         // if mouse button is pressed ON the textfield, set active=true
         if(button.state == SDL_PRESSED)
         {
-            active = (button.x >= getX()) && (button.x < getX() + size_.x) && (button.y >= getY())
-                     && (button.y < getY() + size_.y);
+            active = IsPointInRect(Position(button.x, button.y), Rect(Position(getX(), getY()), Extent(size_)));
         }
     }
     needRender = true;

--- a/CIO/CTextfield.cpp
+++ b/CIO/CTextfield.cpp
@@ -8,7 +8,7 @@
 #include "../globals.h"
 #include "CFont.h"
 
-CTextfield::CTextfield(Sint16 x, Sint16 y, Uint16 cols, Uint16 rows, FontSize fontsize, FontColor text_color,
+CTextfield::CTextfield(Point16 pos, Uint16 cols, Uint16 rows, FontSize fontsize, FontColor text_color,
                        int bg_color, bool button_style)
 {
     active = false;
@@ -16,9 +16,9 @@ CTextfield::CTextfield(Sint16 x, Sint16 y, Uint16 cols, Uint16 rows, FontSize fo
     this->rows = (rows < 1 ? 1 : rows);
     // calc width by maximum number of chiffres (cols) + one blinking chiffre * average pixel_width of a chiffre
     // (fontsize-3) + tolerance for borders
-    this->w = (this->cols + 1) * (static_cast<unsigned>(fontsize) - 3) + 4;
+    this->size_.x = (this->cols + 1) * (static_cast<unsigned>(fontsize) - 3) + 4;
     // calc height ----------------| this is the row_separator from CFont.cpp    |----        + tolerance for borders
-    this->h = this->rows * getLineHeight(fontsize) + 4;
+    this->size_.y = this->rows * getLineHeight(fontsize) + 4;
     setColor(bg_color);
     // allocate memory for the text: chiffres (cols) + '\n' for each line * rows + blinking chiffre + '\0'
     text_.resize((this->cols + 1) * this->rows + 2);
@@ -26,7 +26,7 @@ CTextfield::CTextfield(Sint16 x, Sint16 y, Uint16 cols, Uint16 rows, FontSize fo
     needRender = true;
     rendered = false;
     this->button_style = button_style;
-    textObj = std::make_unique<CFont>("", x, y, fontsize, text_color);
+    textObj = std::make_unique<CFont>("", pos, fontsize, text_color);
 }
 
 int CTextfield::getX() const
@@ -144,7 +144,7 @@ void CTextfield::setMouseData(SDL_MouseButtonEvent button)
         // if mouse button is pressed ON the textfield, set active=true
         if(button.state == SDL_PRESSED)
         {
-            active = (button.x >= getX()) && (button.x < getX() + w) && (button.y >= getY()) && (button.y < getY() + h);
+            active = (button.x >= getX()) && (button.x < getX() + size_.x) && (button.y >= getY()) && (button.y < getY() + size_.y);
         }
     }
     needRender = true;
@@ -274,7 +274,7 @@ bool CTextfield::render()
     // if we need a new surface
     if(!Surf_Text)
     {
-        Surf_Text = makeRGBSurface(w, h);
+        Surf_Text = makeRGBSurface(size_.x, size_.y);
         if(!Surf_Text)
             return false;
     }
@@ -290,13 +290,13 @@ bool CTextfield::render()
             pic = pic_foreground;
 
         // at first completly fill the background (not the fastest way, but simplier)
-        if(w <= global::bmpArray[pic].w)
-            pic_w = w;
+        if(size_.x <= global::bmpArray[pic].w)
+            pic_w = size_.x;
         else
             pic_w = global::bmpArray[pic].w;
 
-        if(h <= global::bmpArray[pic].h)
-            pic_h = h;
+        if(size_.y <= global::bmpArray[pic].h)
+            pic_h = size_.y;
         else
             pic_h = global::bmpArray[pic].h;
 
@@ -339,55 +339,55 @@ bool CTextfield::render()
                 // black frame is left and up
                 // draw vertical line
                 pos_x = 0;
-                for(int y = 0; y < h; y++)
+                for(int y = 0; y < size_.y; y++)
                     CSurface::DrawPixel_RGB(Surf_Text, pos_x, y, 0, 0, 0);
 
                 // draw vertical line
                 pos_x = 1;
-                for(int y = 0; y < h - 1; y++)
+                for(int y = 0; y < size_.y - 1; y++)
                     CSurface::DrawPixel_RGB(Surf_Text, pos_x, y, 0, 0, 0);
 
                 // draw horizontal line
                 pos_y = 0;
-                for(int x = 0; x < w; x++)
+                for(int x = 0; x < size_.x; x++)
                     CSurface::DrawPixel_RGB(Surf_Text, x, pos_y, 0, 0, 0);
 
                 // draw horizontal line
                 pos_y = 1;
-                for(int x = 0; x < w - 1; x++)
+                for(int x = 0; x < size_.x - 1; x++)
                     CSurface::DrawPixel_RGB(Surf_Text, x, pos_y, 0, 0, 0);
             } else
             {
                 // black frame is right and down
                 // draw vertical line
-                pos_x = w - 1;
-                for(int y = 0; y < h; y++)
+                pos_x = size_.x - 1;
+                for(int y = 0; y < size_.y; y++)
                     CSurface::DrawPixel_RGB(Surf_Text, pos_x, y, 0, 0, 0);
 
                 // draw vertical line
-                pos_x = w - 2;
-                for(int y = 1; y < h; y++)
+                pos_x = size_.x - 2;
+                for(int y = 1; y < size_.y; y++)
                     CSurface::DrawPixel_RGB(Surf_Text, pos_x, y, 0, 0, 0);
 
                 // draw horizontal line
-                pos_y = h - 1;
-                for(int x = 0; x < w; x++)
+                pos_y = size_.y - 1;
+                for(int x = 0; x < size_.x; x++)
                     CSurface::DrawPixel_RGB(Surf_Text, x, pos_y, 0, 0, 0);
 
                 // draw horizontal line
-                pos_y = h - 2;
-                for(int x = 1; x < w; x++)
+                pos_y = size_.y - 2;
+                for(int x = 1; x < size_.x; x++)
                     CSurface::DrawPixel_RGB(Surf_Text, x, pos_y, 0, 0, 0);
             }
 
             // draw the foreground --> at first the color (marked or unmarked) and then the picture or text
-            if(w <= global::bmpArray[pic_foreground].w)
-                pic_w = w;
+            if(size_.x <= global::bmpArray[pic_foreground].w)
+                pic_w = size_.x;
             else
                 pic_w = global::bmpArray[pic_foreground].w;
 
-            if(h <= global::bmpArray[pic_foreground].h)
-                pic_h = h;
+            if(size_.y <= global::bmpArray[pic_foreground].h)
+                pic_h = size_.y;
             else
                 pic_h = global::bmpArray[pic_foreground].h;
 

--- a/CIO/CTextfield.h
+++ b/CIO/CTextfield.h
@@ -19,8 +19,7 @@ private:
     SdlSurface Surf_Text;
     std::unique_ptr<CFont> textObj;
     bool needRender;
-    Uint16 w;
-    Uint16 h;
+    Extent16 size_;
     Uint16 cols;
     Uint16 rows;
     int pic_background;
@@ -35,13 +34,13 @@ private:
 
 public:
     // Constructor - Destructor
-    CTextfield(Sint16 x = 0, Sint16 y = 0, Uint16 cols = 10, Uint16 rows = 1, FontSize fontsize = FontSize::Large,
+    CTextfield(Point16 pos = {0, 0}, Uint16 cols = 10, Uint16 rows = 1, FontSize fontsize = FontSize::Large,
                FontColor text_color = FontColor::Yellow, int bg_color = -1, bool button_style = false);
     // Access
     int getX() const;
     int getY() const;
-    int getW() const { return w; }
-    int getH() const { return h; }
+    int getW() const { return size_.x; }
+    int getH() const { return size_.y; }
     int getCols() const { return cols; }
     int getRows() const { return rows; }
     void setX(int x);

--- a/CIO/CTextfield.h
+++ b/CIO/CTextfield.h
@@ -19,7 +19,7 @@ private:
     SdlSurface Surf_Text;
     std::unique_ptr<CFont> textObj;
     bool needRender;
-    Extent16 size_;
+    Extent size_;
     Uint16 cols;
     Uint16 rows;
     int pic_background;
@@ -34,13 +34,12 @@ private:
 
 public:
     // Constructor - Destructor
-    CTextfield(Point16 pos = {0, 0}, Uint16 cols = 10, Uint16 rows = 1, FontSize fontsize = FontSize::Large,
+    CTextfield(Position pos = {0, 0}, Uint16 cols = 10, Uint16 rows = 1, FontSize fontsize = FontSize::Large,
                FontColor text_color = FontColor::Yellow, int bg_color = -1, bool button_style = false);
     // Access
     int getX() const;
     int getY() const;
-    int getW() const { return size_.x; }
-    int getH() const { return size_.y; }
+    const Extent& getSize() const { return size_; };
     int getCols() const { return cols; }
     int getRows() const { return rows; }
     void setX(int x);

--- a/CMap.cpp
+++ b/CMap.cpp
@@ -112,9 +112,9 @@ void CMap::constructMap(const boost::filesystem::path& filepath, int width, int 
     {
         for(int j = 0; j < map->width; j++)
         {
-            modifyBuild(j, i);
-            modifyShading(j, i);
-            modifyResource(j, i);
+            modifyBuild(Position(j, i));
+            modifyShading(Position(j, i));
+            modifyResource(Position(j, i));
         }
     }
 
@@ -337,10 +337,10 @@ void CMap::rotateMap()
     {
         for(int x = 0; x < map->width; x++)
         {
-            modifyBuild(x, y);
-            modifyShading(x, y);
-            modifyResource(x, y);
-            CSurface::update_shading(*map, x, y);
+            modifyBuild(Position(x, y));
+            modifyShading(Position(x, y));
+            modifyResource(Position(x, y));
+            CSurface::update_shading(*map, Position(x, y));
         }
     }
 
@@ -368,10 +368,10 @@ void CMap::MirrorMapOnXAxis()
     {
         for(int x = 0; x < map->width; x++)
         {
-            modifyBuild(x, y);
-            modifyShading(x, y);
-            modifyResource(x, y);
-            CSurface::update_shading(*map, x, y);
+            modifyBuild(Position(x, y));
+            modifyShading(Position(x, y));
+            modifyResource(Position(x, y));
+            CSurface::update_shading(*map, Position(x, y));
         }
     }
 }
@@ -397,10 +397,10 @@ void CMap::MirrorMapOnYAxis()
     {
         for(int x = 0; x < map->width; x++)
         {
-            modifyBuild(x, y);
-            modifyShading(x, y);
-            modifyResource(x, y);
-            CSurface::update_shading(*map, x, y);
+            modifyBuild(Position(x, y));
+            modifyShading(Position(x, y));
+            modifyResource(Position(x, y));
+            CSurface::update_shading(*map, Position(x, y));
         }
     }
 }
@@ -507,7 +507,7 @@ void CMap::setMouseData(const SDL_MouseMotionEvent& motion)
         SDL_EventState(SDL_MOUSEMOTION, SDL_ENABLE);
     }
 
-    storeVerticesFromMouse(motion.x, motion.y, motion.state);
+    storeVerticesFromMouse(Position(motion.x, motion.y), motion.state);
 }
 
 void CMap::onLeftMouseDown(const Point32& pos)
@@ -981,7 +981,7 @@ void CMap::setKeyboardData(const SDL_KeyboardEvent& key)
     }
 }
 
-void CMap::storeVerticesFromMouse(Uint16 MouseX, Uint16 MouseY, Uint8 /*MouseState*/)
+void CMap::storeVerticesFromMouse(Position mousePos, Uint8 /*MouseState*/)
 {
     // if user raises or reduces the height of a vertex, don't let the cursor jump to another vertex
     // if ( (MouseState == SDL_PRESSED) && (mode == EDITOR_MODE_HEIGHT_RAISE || mode == EDITOR_MODE_HEIGHT_REDUCE) )
@@ -993,25 +993,25 @@ void CMap::storeVerticesFromMouse(Uint16 MouseX, Uint16 MouseY, Uint8 /*MouseSta
     // get X
     // following out commented lines are the correct ones, but for tolerance (to prevent to early jumps of the cursor)
     // we subtract "TRIANGLE_WIDTH/2"  Xeven = (MouseX + displayRect.left) / TRIANGLE_WIDTH;
-    Xeven = (MouseX + displayRect.left - TRIANGLE_WIDTH / 2) / TRIANGLE_WIDTH;
+    Xeven = (mousePos.x + displayRect.left - TRIANGLE_WIDTH / 2) / TRIANGLE_WIDTH;
     if(Xeven < 0)
         Xeven += (map->width);
     else if(Xeven > map->width - 1)
         Xeven -= (map->width - 1);
     // Add rows are already shifted by TRIANGLE_WIDTH / 2
-    Xodd = (MouseX + displayRect.left) / TRIANGLE_WIDTH;
-    // Xodd = (MouseX + displayRect.left) / TRIANGLE_WIDTH;
+    Xodd = (mousePos.x + displayRect.left) / TRIANGLE_WIDTH;
+    // Xodd = (mousePos.x + displayRect.left) / TRIANGLE_WIDTH;
     if(Xodd < 0)
         Xodd += (map->width - 1);
     else if(Xodd > map->width - 1)
         Xodd -= (map->width);
 
-    MousePosY = MouseY + displayRect.top;
+    MousePosY = mousePos.y + displayRect.top;
     // correct mouse position Y if displayRect is outside map edges
     if(MousePosY < 0)
         MousePosY += map->height_pixel;
     else if(MousePosY > map->height_pixel)
-        MousePosY = MouseY - (map->height_pixel - displayRect.top);
+        MousePosY = mousePos.y - (map->height_pixel - displayRect.top);
 
     // get Y
     for(int j = 0; j < map->height; j++)
@@ -1273,10 +1273,10 @@ void CMap::render()
     CSurface::Draw(Surf_Map, global::bmpArray[CURSOR_SYMBOL_ARROW_UP].surface, rightMenubarPos - Extent(20, 220));
     // bugkill picture for quickload with text
     CSurface::Draw(Surf_Map, global::bmpArray[MENUBAR_BUGKILL].surface, rightMenubarPos + Position(-37, 162));
-    CFont::writeText(Surf_Map, "Load", rightMenubarPos.x - 35, rightMenubarPos.y + 193);
+    CFont::writeText(Surf_Map, "Load", Position(rightMenubarPos.x - 35, rightMenubarPos.y + 193));
     // bugkill picture for quicksave with text
     CSurface::Draw(Surf_Map, global::bmpArray[MENUBAR_BUGKILL].surface, rightMenubarPos + Position(-37, 200));
-    CFont::writeText(Surf_Map, "Save", rightMenubarPos.x - 35, rightMenubarPos.y + 231);
+    CFont::writeText(Surf_Map, "Save", Position(rightMenubarPos.x - 35, rightMenubarPos.y + 231));
 }
 
 static void getTriangleColor(TriangleTerrainType terrainType, MapType mapType, Sint16& r, Sint16& g, Sint16& b)
@@ -1458,12 +1458,12 @@ void CMap::modifyVertex()
     {
         for(int i = 0; i < VertexCounter; i++)
             if(Vertices[i].active)
-                modifyHeightRaise(Vertices[i].x, Vertices[i].y);
+                modifyHeightRaise(Vertices[i]);
     } else if(mode == EDITOR_MODE_HEIGHT_REDUCE)
     {
         for(int i = 0; i < VertexCounter; i++)
             if(Vertices[i].active)
-                modifyHeightReduce(Vertices[i].x, Vertices[i].y);
+                modifyHeightReduce(Vertices[i]);
     } else if(mode == EDITOR_MODE_HEIGHT_PLANE)
     {
         // calculate height average over all vertices
@@ -1486,15 +1486,15 @@ void CMap::modifyVertex()
 
             for(int i = 0; i < VertexCounter; i++)
                 if(Vertices[i].active)
-                    modifyHeightPlane(Vertices[i].x, Vertices[i].y, h_avg);
+                    modifyHeightPlane(Vertices[i], h_avg);
         }
     } else if(mode == EDITOR_MODE_HEIGHT_MAKE_BIG_HOUSE)
     {
-        modifyHeightMakeBigHouse(Vertex_.x, Vertex_.y);
+        modifyHeightMakeBigHouse(Vertex_);
     } else if(mode == EDITOR_MODE_TEXTURE_MAKE_HARBOUR)
     {
-        modifyHeightMakeBigHouse(Vertex_.x, Vertex_.y);
-        modifyTextureMakeHarbour(Vertex_.x, Vertex_.y);
+        modifyHeightMakeBigHouse(Vertex_);
+        modifyTextureMakeHarbour(Vertex_);
     }
     // at this time we need a modeContent to set
     else if(mode == EDITOR_MODE_CUT)
@@ -1503,52 +1503,52 @@ void CMap::modifyVertex()
         {
             if(Vertices[i].active)
             {
-                modifyObject(Vertices[i].x, Vertices[i].y);
-                modifyAnimal(Vertices[i].x, Vertices[i].y);
+                modifyObject(Vertices[i]);
+                modifyAnimal(Vertices[i]);
             }
         }
     } else if(mode == EDITOR_MODE_TEXTURE)
     {
         for(int i = 0; i < VertexCounter; i++)
             if(Vertices[i].active)
-                modifyTexture(Vertices[i].x, Vertices[i].y, Vertices[i].fill_rsu, Vertices[i].fill_usd);
+                modifyTexture(Vertices[i], Vertices[i].fill_rsu, Vertices[i].fill_usd);
     } else if(mode == EDITOR_MODE_TREE)
     {
         for(int i = 0; i < VertexCounter; i++)
             if(Vertices[i].active)
-                modifyObject(Vertices[i].x, Vertices[i].y);
+                modifyObject(Vertices[i]);
     } else if(mode == EDITOR_MODE_LANDSCAPE)
     {
         for(int i = 0; i < VertexCounter; i++)
             if(Vertices[i].active)
-                modifyObject(Vertices[i].x, Vertices[i].y);
+                modifyObject(Vertices[i]);
     } else if(mode == EDITOR_MODE_RESOURCE_RAISE || mode == EDITOR_MODE_RESOURCE_REDUCE)
     {
         for(int i = 0; i < VertexCounter; i++)
             if(Vertices[i].active)
-                modifyResource(Vertices[i].x, Vertices[i].y);
+                modifyResource(Vertices[i]);
     } else if(mode == EDITOR_MODE_ANIMAL)
     {
         for(int i = 0; i < VertexCounter; i++)
             if(Vertices[i].active)
-                modifyAnimal(Vertices[i].x, Vertices[i].y);
+                modifyAnimal(Vertices[i]);
     } else if(mode == EDITOR_MODE_FLAG || mode == EDITOR_MODE_FLAG_DELETE)
     {
-        modifyPlayer(Vertex_.x, Vertex_.y);
+        modifyPlayer(Vertex_);
     }
 }
 
-void CMap::modifyHeightRaise(int VertexX, int VertexY)
+void CMap::modifyHeightRaise(Position pos)
 {
     // vertex count for the points
     int X, Y;
-    MapNode* tempP = &map->getVertex(VertexX, VertexY);
+    MapNode* tempP = &map->getVertex(pos.x, pos.y);
     // this is to setup the building depending on the vertices around
     std::array<Point32, 19> tempVertices;
-    calculateVerticesAround(tempVertices, VertexX, VertexY);
+    calculateVerticesAround(tempVertices, pos);
 
     bool even = false;
-    if(VertexY % 2 == 0)
+    if(pos.y % 2 == 0)
         even = true;
 
     // DO IT
@@ -1561,91 +1561,91 @@ void CMap::modifyHeightRaise(int VertexX, int VertexY)
     tempP->y -= TRIANGLE_INCREASE;
     tempP->z += TRIANGLE_INCREASE;
     tempP->h += 0x01;
-    CSurface::update_shading(*map, VertexX, VertexY);
+    CSurface::update_shading(*map, pos);
 
     // after (5*TRIANGLE_INCREASE) pixel all vertices around will be raised too
     // update first vertex left upside
-    X = VertexX - (even ? 1 : 0);
+    X = pos.x - (even ? 1 : 0);
     if(X < 0)
         X += map->width;
-    Y = VertexY - 1;
+    Y = pos.y - 1;
     if(Y < 0)
         Y += map->height;
     // only modify if the other point is lower than the middle point of the hexagon (-5 cause point was raised a few
     // lines before)
     if(map->getVertex(X, Y).z < tempP->z - (5 * TRIANGLE_INCREASE)) //-V807
-        modifyHeightRaise(X, Y);
+        modifyHeightRaise(Position(X, Y));
     // update second vertex right upside
-    X = VertexX + (even ? 0 : 1);
+    X = pos.x + (even ? 0 : 1);
     if(X >= map->width)
         X -= map->width;
-    Y = VertexY - 1;
+    Y = pos.y - 1;
     if(Y < 0)
         Y += map->height;
     // only modify if the other point is lower than the middle point of the hexagon (-5 cause point was raised a few
     // lines before)
     if(map->getVertex(X, Y).z < tempP->z - (5 * TRIANGLE_INCREASE))
-        modifyHeightRaise(X, Y);
+        modifyHeightRaise(Position(X, Y));
     // update third point bottom left
-    X = VertexX - 1;
+    X = pos.x - 1;
     if(X < 0)
         X += map->width;
-    Y = VertexY;
+    Y = pos.y;
     // only modify if the other point is lower than the middle point of the hexagon (-5 cause point was raised a few
     // lines before)
     if(map->getVertex(X, Y).z < tempP->z - (5 * TRIANGLE_INCREASE))
-        modifyHeightRaise(X, Y);
+        modifyHeightRaise(Position(X, Y));
     // update fourth point bottom right
-    X = VertexX + 1;
+    X = pos.x + 1;
     if(X >= map->width)
         X -= map->width;
-    Y = VertexY;
+    Y = pos.y;
     // only modify if the other point is lower than the middle point of the hexagon (-5 cause point was raised a few
     // lines before)
     if(map->getVertex(X, Y).z < tempP->z - (5 * TRIANGLE_INCREASE))
-        modifyHeightRaise(X, Y);
+        modifyHeightRaise(Position(X, Y));
     // update fifth point down left
-    X = VertexX - (even ? 1 : 0);
+    X = pos.x - (even ? 1 : 0);
     if(X < 0)
         X += map->width;
-    Y = VertexY + 1;
+    Y = pos.y + 1;
     if(Y >= map->height)
         Y -= map->height;
     // only modify if the other point is lower than the middle point of the hexagon (-5 cause point was raised a few
     // lines before)
     if(map->getVertex(X, Y).z < tempP->z - (5 * TRIANGLE_INCREASE))
-        modifyHeightRaise(X, Y);
+        modifyHeightRaise(Position(X, Y));
     // update sixth point down right
-    X = VertexX + (even ? 0 : 1);
+    X = pos.x + (even ? 0 : 1);
     if(X >= map->width)
         X -= map->width;
-    Y = VertexY + 1;
+    Y = pos.y + 1;
     if(Y >= map->height)
         Y -= map->height;
     // only modify if the other point is lower than the middle point of the hexagon (-5 cause point was raised a few
     // lines before)
     if(map->getVertex(X, Y).z < tempP->z - (5 * TRIANGLE_INCREASE))
-        modifyHeightRaise(X, Y);
+        modifyHeightRaise(Position(X, Y));
 
     // at least setup the possible building and shading at the vertex and 2 sections around
     for(int i = 0; i < 19; i++)
     {
-        modifyBuild(tempVertices[i].x, tempVertices[i].y);
-        modifyShading(tempVertices[i].x, tempVertices[i].y);
+        modifyBuild(tempVertices[i]);
+        modifyShading(tempVertices[i]);
     }
 }
 
-void CMap::modifyHeightReduce(int VertexX, int VertexY)
+void CMap::modifyHeightReduce(Position pos)
 {
     // vertex count for the points
     int X, Y;
-    MapNode* tempP = &map->getVertex(VertexX, VertexY);
+    MapNode* tempP = &map->getVertex(pos.x, pos.y);
     // this is to setup the building depending on the vertices around
     std::array<Point32, 19> tempVertices;
-    calculateVerticesAround(tempVertices, VertexX, VertexY);
+    calculateVerticesAround(tempVertices, pos);
 
     bool even = false;
-    if(VertexY % 2 == 0)
+    if(pos.y % 2 == 0)
         even = true;
 
     // DO IT
@@ -1658,96 +1658,96 @@ void CMap::modifyHeightReduce(int VertexX, int VertexY)
     tempP->y += TRIANGLE_INCREASE;
     tempP->z -= TRIANGLE_INCREASE;
     tempP->h -= 0x01;
-    CSurface::update_shading(*map, VertexX, VertexY);
+    CSurface::update_shading(*map, pos);
     // after (5*TRIANGLE_INCREASE) pixel all vertices around will be reduced too
     // update first vertex left upside
-    X = VertexX - (even ? 1 : 0);
+    X = pos.x - (even ? 1 : 0);
     if(X < 0)
         X += map->width;
-    Y = VertexY - 1;
+    Y = pos.y - 1;
     if(Y < 0)
         Y += map->height;
     // only modify if the other point is higher than the middle point of the hexagon (+5 cause point was reduced a few
     // lines before)
     if(map->getVertex(X, Y).z > tempP->z + (5 * TRIANGLE_INCREASE)) //-V807
-        modifyHeightReduce(X, Y);
+        modifyHeightReduce(Position(X, Y));
     // update second vertex right upside
-    X = VertexX + (even ? 0 : 1);
+    X = pos.x + (even ? 0 : 1);
     if(X >= map->width)
         X -= map->width;
-    Y = VertexY - 1;
+    Y = pos.y - 1;
     if(Y < 0)
         Y += map->height;
     // only modify if the other point is higher than the middle point of the hexagon (+5 cause point was reduced a few
     // lines before)
     if(map->getVertex(X, Y).z > tempP->z + (5 * TRIANGLE_INCREASE))
-        modifyHeightReduce(X, Y);
+        modifyHeightReduce(Position(X, Y));
     // update third point bottom left
-    X = VertexX - 1;
+    X = pos.x - 1;
     if(X < 0)
         X += map->width;
-    Y = VertexY;
+    Y = pos.y;
     // only modify if the other point is higher than the middle point of the hexagon (+5 cause point was reduced a few
     // lines before)
     if(map->getVertex(X, Y).z > tempP->z + (5 * TRIANGLE_INCREASE))
-        modifyHeightReduce(X, Y);
+        modifyHeightReduce(Position(X, Y));
     // update fourth point bottom right
-    X = VertexX + 1;
+    X = pos.x + 1;
     if(X >= map->width)
         X -= map->width;
-    Y = VertexY;
+    Y = pos.y;
     // only modify if the other point is higher than the middle point of the hexagon (+5 cause point was reduced a few
     // lines before)
     if(map->getVertex(X, Y).z > tempP->z + (5 * TRIANGLE_INCREASE))
-        modifyHeightReduce(X, Y);
+        modifyHeightReduce(Position(X, Y));
     // update fifth point down left
-    X = VertexX - (even ? 1 : 0);
+    X = pos.x - (even ? 1 : 0);
     if(X < 0)
         X += map->width;
-    Y = VertexY + 1;
+    Y = pos.y + 1;
     if(Y >= map->height)
         Y -= map->height;
     // only modify if the other point is higher than the middle point of the hexagon (+5 cause point was reduced a few
     // lines before)
     if(map->getVertex(X, Y).z > tempP->z + (5 * TRIANGLE_INCREASE))
-        modifyHeightReduce(X, Y);
+        modifyHeightReduce(Position(X, Y));
     // update sixth point down right
-    X = VertexX + (even ? 0 : 1);
+    X = pos.x + (even ? 0 : 1);
     if(X >= map->width)
         X -= map->width;
-    Y = VertexY + 1;
+    Y = pos.y + 1;
     if(Y >= map->height)
         Y -= map->height;
     // only modify if the other point is higher than the middle point of the hexagon (+5 cause point was reduced a few
     // lines before)
     if(map->getVertex(X, Y).z > tempP->z + (5 * TRIANGLE_INCREASE))
-        modifyHeightReduce(X, Y);
+        modifyHeightReduce(Position(X, Y));
 
     // at least setup the possible building and shading at the vertex and 2 sections around
     for(int i = 0; i < 19; i++)
     {
-        modifyBuild(tempVertices[i].x, tempVertices[i].y);
-        modifyShading(tempVertices[i].x, tempVertices[i].y);
+        modifyBuild(tempVertices[i]);
+        modifyShading(tempVertices[i]);
     }
 }
 
-void CMap::modifyHeightPlane(int VertexX, int VertexY, Uint8 h)
+void CMap::modifyHeightPlane(Position pos, Uint8 h)
 {
     // we could do "while" but "if" looks better during planing (optical effect)
-    if(map->getVertex(VertexX, VertexY).h < h)
-        modifyHeightRaise(VertexX, VertexY);
+    if(map->getVertex(pos.x, pos.y).h < h)
+        modifyHeightRaise(pos);
     // we could do "while" but "if" looks better during planing (optical effect)
-    if(map->getVertex(VertexX, VertexY).h > h)
-        modifyHeightReduce(VertexX, VertexY);
+    if(map->getVertex(pos.x, pos.y).h > h)
+        modifyHeightReduce(pos);
 }
 
-void CMap::modifyHeightMakeBigHouse(int VertexX, int VertexY)
+void CMap::modifyHeightMakeBigHouse(Position pos)
 {
     // at first save all vertices we need to calculate the new building
     std::array<Point32, 19> tempVertices;
-    calculateVerticesAround(tempVertices, VertexX, VertexY);
+    calculateVerticesAround(tempVertices, pos);
 
-    MapNode& middleVertex = map->getVertex(VertexX, VertexY);
+    MapNode& middleVertex = map->getVertex(pos.x, pos.y);
     Uint8 height = middleVertex.h;
 
     // calculate the building using the height of the vertices
@@ -1757,19 +1757,19 @@ void CMap::modifyHeightMakeBigHouse(int VertexX, int VertexY)
     {
         MapNode& vertex = map->getVertex(tempVertices[i]);
         for(int j = height - vertex.h; j >= 0x04; --j)
-            modifyHeightRaise(tempVertices[i].x, tempVertices[i].y);
+            modifyHeightRaise(tempVertices[i]);
 
         for(int j = vertex.h - height; j >= 0x04; --j)
-            modifyHeightReduce(tempVertices[i].x, tempVertices[i].y);
+            modifyHeightReduce(tempVertices[i]);
     }
 
     // test vertex lower right
     MapNode& vertex = map->getVertex(tempVertices[6]);
     for(int j = height - vertex.h; j >= 0x04; --j)
-        modifyHeightRaise(tempVertices[6].x, tempVertices[6].y);
+        modifyHeightRaise(tempVertices[6]);
 
     for(int j = vertex.h - height; j >= 0x02; --j)
-        modifyHeightReduce(tempVertices[6].x, tempVertices[6].y);
+        modifyHeightReduce(tempVertices[6]);
 
     // now test the second section around the vertex
 
@@ -1778,10 +1778,10 @@ void CMap::modifyHeightMakeBigHouse(int VertexX, int VertexY)
     {
         MapNode& vertex = map->getVertex(tempVertices[i]);
         for(int j = height - vertex.h; j >= 0x03; --j)
-            modifyHeightRaise(tempVertices[i].x, tempVertices[i].y);
+            modifyHeightRaise(tempVertices[i]);
 
         for(int j = vertex.h - height; j >= 0x03; --j)
-            modifyHeightReduce(tempVertices[i].x, tempVertices[i].y);
+            modifyHeightReduce(tempVertices[i]);
     }
 
     // remove harbour if there is one
@@ -1797,14 +1797,14 @@ void CMap::modifyHeightMakeBigHouse(int VertexX, int VertexY)
     }
 }
 
-void CMap::modifyShading(int VertexX, int VertexY)
+void CMap::modifyShading(Position pos)
 {
     // temporary to keep the lines short
     int X, Y;
     // this is to setup the shading depending on the vertices around (2 sections from the cursor)
     std::array<Point32, 19> tempVertices;
-    calculateVerticesAround(tempVertices, VertexX, VertexY);
-    MapNode& middleVertex = map->getVertex(VertexX, VertexY);
+    calculateVerticesAround(tempVertices, pos);
+    MapNode& middleVertex = map->getVertex(pos.x, pos.y);
 
     // shading stakes
     int A, B, C, D, Result;
@@ -1835,7 +1835,7 @@ void CMap::modifyShading(int VertexX, int VertexY)
     middleVertex.shading = Result;
 }
 
-void CMap::modifyTexture(int VertexX, int VertexY, bool rsu, bool usd)
+void CMap::modifyTexture(Position pos, bool rsu, bool usd)
 {
     if(modeContent == TRIANGLE_TEXTURE_MEADOW_MIXED || modeContent == TRIANGLE_TEXTURE_MEADOW_MIXED_HARBOUR)
     {
@@ -1860,31 +1860,31 @@ void CMap::modifyTexture(int VertexX, int VertexY, bool rsu, bool usd)
                 newContent = TRIANGLE_TEXTURE_MEADOW3_HARBOUR;
         }
         if(rsu)
-            map->getVertex(VertexX, VertexY).rsuTexture = newContent;
+            map->getVertex(pos.x, pos.y).rsuTexture = newContent;
         if(usd)
-            map->getVertex(VertexX, VertexY).usdTexture = newContent;
+            map->getVertex(pos.x, pos.y).usdTexture = newContent;
     } else
     {
         if(rsu)
-            map->getVertex(VertexX, VertexY).rsuTexture = modeContent;
+            map->getVertex(pos.x, pos.y).rsuTexture = modeContent;
         if(usd)
-            map->getVertex(VertexX, VertexY).usdTexture = modeContent;
+            map->getVertex(pos.x, pos.y).usdTexture = modeContent;
     }
 
     // at least setup the possible building and the resources at the vertex and 1 section/2 sections around
     std::array<Point32, 19> tempVertices;
-    calculateVerticesAround(tempVertices, VertexX, VertexY);
+    calculateVerticesAround(tempVertices, pos);
     for(int i = 0; i < 19; i++)
     {
         if(i < 7)
-            modifyBuild(tempVertices[i].x, tempVertices[i].y);
-        modifyResource(tempVertices[i].x, tempVertices[i].y);
+            modifyBuild(tempVertices[i]);
+        modifyResource(tempVertices[i]);
     }
 }
 
-void CMap::modifyTextureMakeHarbour(int VertexX, int VertexY)
+void CMap::modifyTextureMakeHarbour(Position pos)
 {
-    MapNode& vertex = map->getVertex(VertexX, VertexY);
+    MapNode& vertex = map->getVertex(pos.x, pos.y);
     if(vertex.rsuTexture == TRIANGLE_TEXTURE_STEPPE_MEADOW1 || vertex.rsuTexture == TRIANGLE_TEXTURE_MEADOW1
        || vertex.rsuTexture == TRIANGLE_TEXTURE_MEADOW2 || vertex.rsuTexture == TRIANGLE_TEXTURE_MEADOW3
        || vertex.rsuTexture == TRIANGLE_TEXTURE_STEPPE_MEADOW2 || vertex.rsuTexture == TRIANGLE_TEXTURE_FLOWER
@@ -1894,9 +1894,9 @@ void CMap::modifyTextureMakeHarbour(int VertexX, int VertexY)
     }
 }
 
-void CMap::modifyObject(int x, int y)
+void CMap::modifyObject(Position pos)
 {
-    MapNode& curVertex = map->getVertex(x, y);
+    MapNode& curVertex = map->getVertex(pos.x, pos.y);
     if(mode == EDITOR_MODE_CUT)
     {
         // prevent cutting a player position
@@ -1968,7 +1968,7 @@ void CMap::modifyObject(int x, int y)
             curVertex.objectInfo = newContent2;
 
             // now set up the buildings around the granite
-            modifyBuild(x, y);
+            modifyBuild(pos);
         } else if(modeContent == 0x05)
         {
             int newContent = modeContent + rand() % 2;
@@ -2053,38 +2053,38 @@ void CMap::modifyObject(int x, int y)
     }
     // at least setup the possible building at the vertex and 1 section around
     std::array<Point32, 7> tempVertices;
-    calculateVerticesAround(tempVertices, x, y);
+    calculateVerticesAround(tempVertices, pos);
     for(int i = 0; i < 7; i++)
-        modifyBuild(tempVertices[i].x, tempVertices[i].y);
+        modifyBuild(tempVertices[i]);
 }
 
-void CMap::modifyAnimal(int VertexX, int VertexY)
+void CMap::modifyAnimal(Position pos)
 {
     if(mode == EDITOR_MODE_CUT)
     {
-        map->getVertex(VertexX, VertexY).animal = 0x00;
+        map->getVertex(pos.x, pos.y).animal = 0x00;
     } else if(mode == EDITOR_MODE_ANIMAL)
     {
         // if there is another object at the vertex, return
-        if(map->getVertex(VertexX, VertexY).animal != 0x00)
+        if(map->getVertex(pos.x, pos.y).animal != 0x00)
             return;
 
         if(modeContent > 0x00 && modeContent <= 0x06)
-            map->getVertex(VertexX, VertexY).animal = modeContent;
+            map->getVertex(pos.x, pos.y).animal = modeContent;
     }
 }
 
-void CMap::modifyBuild(int x, int y)
+void CMap::modifyBuild(Position pos)
 {
     // at first save all vertices we need to calculate the new building
     std::array<Point32, 19> tempVertices;
-    calculateVerticesAround(tempVertices, x, y);
+    calculateVerticesAround(tempVertices, pos);
 
     /// evtl. keine festen werte sondern addition und subtraktion wegen originalkompatibilitaet (bei baeumen bspw. keine
     /// 0x00 sondern 0x68)
 
     Uint8 building;
-    MapNode& curVertex = map->getVertex(x, y);
+    MapNode& curVertex = map->getVertex(pos.x, pos.y);
     const Uint8 height = curVertex.h;
     std::array<const MapNode*, 7> mapVertices;
     for(unsigned i = 0; i < mapVertices.size(); i++)
@@ -2347,12 +2347,12 @@ void CMap::modifyBuild(int x, int y)
     curVertex.build = building;
 }
 
-void CMap::modifyResource(int x, int y)
+void CMap::modifyResource(Position pos)
 {
     // at first save all vertices we need to check
     std::array<Point32, 19> tempVertices;
-    calculateVerticesAround(tempVertices, x, y);
-    MapNode& curVertex = map->getVertex(x, y);
+    calculateVerticesAround(tempVertices, pos);
+    MapNode& curVertex = map->getVertex(pos.x, pos.y);
     std::array<const MapNode*, 7> mapVertices;
     for(unsigned i = 0; i < mapVertices.size(); i++)
         mapVertices[i] = &map->getVertex(tempVertices[i]);
@@ -2532,13 +2532,13 @@ void CMap::modifyResource(int x, int y)
         curVertex.resource = 0x00;
 }
 
-void CMap::modifyPlayer(int VertexX, int VertexY)
+void CMap::modifyPlayer(Position pos)
 {
     // if we have repositioned a player, we need the old position to recalculate the buildings there
     bool PlayerRePositioned = false;
     int oldPositionX = 0;
     int oldPositionY = 0;
-    MapNode& vertex = map->getVertex(VertexX, VertexY);
+    MapNode& vertex = map->getVertex(pos.x, pos.y);
 
     // set player position
     if(mode == EDITOR_MODE_FLAG)
@@ -2553,8 +2553,8 @@ void CMap::modifyPlayer(int VertexX, int VertexY)
             // first 7 players)
             if(modeContent >= 0 && modeContent < 7)
             {
-                map->HQx[modeContent] = VertexX;
-                map->HQy[modeContent] = VertexY;
+                map->HQx[modeContent] = pos.x;
+                map->HQy[modeContent] = pos.y;
             }
 
             // save old position if exists
@@ -2566,8 +2566,8 @@ void CMap::modifyPlayer(int VertexX, int VertexY)
                 map->getVertex(oldPositionX, oldPositionY).objectInfo = 0x00;
                 PlayerRePositioned = true;
             }
-            PlayerHQx[modeContent] = VertexX;
-            PlayerHQy[modeContent] = VertexY;
+            PlayerHQx[modeContent] = pos.x;
+            PlayerHQy[modeContent] = pos.y;
 
             // setup number of players in map header
             if(!PlayerRePositioned)
@@ -2604,15 +2604,15 @@ void CMap::modifyPlayer(int VertexX, int VertexY)
 
     // at least setup the possible building at the vertex and 2 sections around
     std::array<Point32, 19> tempVertices;
-    calculateVerticesAround(tempVertices, VertexX, VertexY);
+    calculateVerticesAround(tempVertices, pos);
     for(int i = 0; i < 19; i++)
-        modifyBuild(tempVertices[i].x, tempVertices[i].y);
+        modifyBuild(tempVertices[i]);
 
     if(PlayerRePositioned)
     {
-        calculateVerticesAround(tempVertices, oldPositionX, oldPositionY);
+        calculateVerticesAround(tempVertices, Position(oldPositionX, oldPositionY));
         for(int i = 0; i < 19; i++)
-            modifyBuild(tempVertices[i].x, tempVertices[i].y);
+            modifyBuild(tempVertices[i]);
     }
 }
 
@@ -2661,8 +2661,9 @@ void CMap::calculateVertices()
 }
 
 template<size_t T_size>
-void CMap::calculateVerticesAround(std::array<Point32, T_size>& newVertices, int x, int y)
+void CMap::calculateVerticesAround(std::array<Point32, T_size>& newVertices, Position pos)
 {
+    int x = pos.x, y = pos.y;
     static_assert(T_size == 1u || T_size == 7u || T_size == 19u, "Only 1, 7 or 19 are allowed");
     bool even = false;
     if(y % 2 == 0)

--- a/CMap.h
+++ b/CMap.h
@@ -68,7 +68,7 @@ private:
     std::list<SavedVertex> undoBuffer;
     std::list<SavedVertex> redoBuffer;
     // get the number of the triangle nearest to cursor and save it to VertexX and VertexY
-    void storeVerticesFromMouse(Uint16 MouseX, Uint16 MouseY, Uint8 MouseState);
+    void storeVerticesFromMouse(Position mousePos, Uint8 MouseState);
     // blitting coords for the mouse cursor
     Position MouseBlit;
     // counts the distance from the cursor vertex to the farest vertex that can be involved in changes (0 - only cursor
@@ -206,23 +206,23 @@ private:
     //          X=14    X=5     X=6     X=15
     //              X=16    X=17    X=18
     template<size_t T_size>
-    void calculateVerticesAround(std::array<Point32, T_size>& newVertices, int x, int y);
+    void calculateVerticesAround(std::array<Point32, T_size>& newVertices, Position pos);
     // this will setup the 'active' variable of each vertices depending on 'ChangeSection'
     void setupVerticesActivity();
     Position correctMouseBlit(Position vertexPos) const;
     void modifyVertex();
-    void modifyHeightRaise(int VertexX, int VertexY);
-    void modifyHeightReduce(int VertexX, int VertexY);
-    void modifyHeightPlane(int VertexX, int VertexY, Uint8 h);
-    void modifyHeightMakeBigHouse(int VertexX, int VertexY);
-    void modifyShading(int VertexX, int VertexY);
-    void modifyTexture(int VertexX, int VertexY, bool rsu, bool usd);
-    void modifyTextureMakeHarbour(int VertexX, int VertexY);
-    void modifyObject(int x, int y);
-    void modifyAnimal(int VertexX, int VertexY);
-    void modifyBuild(int x, int y);
-    void modifyResource(int x, int y);
-    void modifyPlayer(int VertexX, int VertexY);
+    void modifyHeightRaise(Position pos);
+    void modifyHeightReduce(Position pos);
+    void modifyHeightPlane(Position pos, Uint8 h);
+    void modifyHeightMakeBigHouse(Position pos);
+    void modifyShading(Position pos);
+    void modifyTexture(Position pos, bool rsu, bool usd);
+    void modifyTextureMakeHarbour(Position pos);
+    void modifyObject(Position pos);
+    void modifyAnimal(Position pos);
+    void modifyBuild(Position pos);
+    void modifyResource(Position pos);
+    void modifyPlayer(Position pos);
     void rotateMap();
     void MirrorMapOnXAxis();
     void MirrorMapOnYAxis();

--- a/CSurface.cpp
+++ b/CSurface.cpp
@@ -121,7 +121,7 @@ bool CSurface::Draw(SdlSurface& Surf_Dest, SdlSurface& Surf_Src, int X, int Y, i
     return Draw(Surf_Dest.get(), Surf_Src.get(), X, Y, angle);
 }
 
-bool CSurface::Draw(SDL_Surface* Surf_Dest, SDL_Surface* Surf_Src, Position dest, Extent srcOffset, Extent srcSize)
+bool CSurface::Draw(SDL_Surface* Surf_Dest, SDL_Surface* Surf_Src, Position dest, Position srcOffset, Extent srcSize)
 {
     if(!Surf_Dest || !Surf_Src)
         return false;
@@ -133,8 +133,8 @@ bool CSurface::Draw(SDL_Surface* Surf_Dest, SDL_Surface* Surf_Src, Position dest
 
     SDL_Rect SrcR;
 
-    SrcR.x = static_cast<int>(srcOffset.x);
-    SrcR.y = static_cast<int>(srcOffset.y);
+    SrcR.x = srcOffset.x;
+    SrcR.y = srcOffset.y;
     SrcR.w = static_cast<int>(srcSize.x);
     SrcR.h = static_cast<int>(srcSize.y);
 
@@ -143,7 +143,7 @@ bool CSurface::Draw(SDL_Surface* Surf_Dest, SDL_Surface* Surf_Src, Position dest
     return true;
 }
 
-bool CSurface::Draw(SDL_Surface* Surf_Dest, SdlSurface& Surf_Src, Position dest, Extent srcOffset, Extent srcSize)
+bool CSurface::Draw(SDL_Surface* Surf_Dest, SdlSurface& Surf_Src, Position dest, Position srcOffset, Extent srcSize)
 {
     return Draw(Surf_Dest, Surf_Src.get(), dest, srcOffset, srcSize);
 }

--- a/CSurface.cpp
+++ b/CSurface.cpp
@@ -1330,66 +1330,66 @@ vector CSurface::get_flatVector(const IntVector& P1, const IntVector& P2, const 
     return cross;
 }
 
-void CSurface::update_shading(bobMAP& myMap, int VertexX, int VertexY)
+void CSurface::update_shading(bobMAP& myMap, Position pos)
 {
     // vertex count for the points
     int X, Y;
 
     bool even = false;
-    if(VertexY % 2 == 0)
+    if(pos.y % 2 == 0)
         even = true;
 
-    update_flatVectors(myMap, VertexX, VertexY);
-    update_nodeVector(myMap, VertexX, VertexY);
+    update_flatVectors(myMap, pos);
+    update_nodeVector(myMap, pos);
 
-    // now update all nodeVectors around VertexX and VertexY
+    // now update all nodeVectors around pos
     // update first vertex left upside
-    X = VertexX - (even ? 1 : 0);
+    X = pos.x - (even ? 1 : 0);
     if(X < 0)
         X += myMap.width;
-    Y = VertexY - 1;
+    Y = pos.y - 1;
     if(Y < 0)
         Y += myMap.height;
-    update_nodeVector(myMap, X, Y);
+    update_nodeVector(myMap, Position(X, Y));
     // update second vertex right upside
-    X = VertexX + (even ? 0 : 1);
+    X = pos.x + (even ? 0 : 1);
     if(X >= myMap.width)
         X -= myMap.width;
-    Y = VertexY - 1;
+    Y = pos.y - 1;
     if(Y < 0)
         Y += myMap.height;
-    update_nodeVector(myMap, X, Y);
+    update_nodeVector(myMap, Position(X, Y));
     // update third point bottom left
-    X = VertexX - 1;
+    X = pos.x - 1;
     if(X < 0)
         X += myMap.width;
-    Y = VertexY;
-    update_nodeVector(myMap, X, Y);
+    Y = pos.y;
+    update_nodeVector(myMap, Position(X, Y));
     // update fourth point bottom right
-    X = VertexX + 1;
+    X = pos.x + 1;
     if(X >= myMap.width)
         X -= myMap.width;
-    Y = VertexY;
-    update_nodeVector(myMap, X, Y);
+    Y = pos.y;
+    update_nodeVector(myMap, Position(X, Y));
     // update fifth point down left
-    X = VertexX - (even ? 1 : 0);
+    X = pos.x - (even ? 1 : 0);
     if(X < 0)
         X += myMap.width;
-    Y = VertexY + 1;
+    Y = pos.y + 1;
     if(Y >= myMap.height)
         Y -= myMap.height;
-    update_nodeVector(myMap, X, Y);
+    update_nodeVector(myMap, Position(X, Y));
     // update sixth point down right
-    X = VertexX + (even ? 0 : 1);
+    X = pos.x + (even ? 0 : 1);
     if(X >= myMap.width)
         X -= myMap.width;
-    Y = VertexY + 1;
+    Y = pos.y + 1;
     if(Y >= myMap.height)
         Y -= myMap.height;
-    update_nodeVector(myMap, X, Y);
+    update_nodeVector(myMap, Position(X, Y));
 }
 
-void CSurface::update_flatVectors(bobMAP& myMap, int VertexX, int VertexY)
+void CSurface::update_flatVectors(bobMAP& myMap, Position pos)
 {
     // point structures for the triangles, Pmiddle is the point in the middle of the hexagon we will update
     MapNode *P1, *P2, *P3, *Pmiddle;
@@ -1397,66 +1397,66 @@ void CSurface::update_flatVectors(bobMAP& myMap, int VertexX, int VertexY)
     int P1x, P1y, P2x, P2y, P3x, P3y;
 
     bool even = false;
-    if(VertexY % 2 == 0)
+    if(pos.y % 2 == 0)
         even = true;
 
-    Pmiddle = &myMap.getVertex(VertexX, VertexY);
+    Pmiddle = &myMap.getVertex(pos.x, pos.y);
 
     // update first triangle left upside
-    P1x = VertexX - (even ? 1 : 0);
+    P1x = pos.x - (even ? 1 : 0);
     if(P1x < 0)
         P1x += myMap.width;
-    P1y = VertexY - 1;
+    P1y = pos.y - 1;
     if(P1y < 0)
         P1y += myMap.height;
     P1 = &myMap.getVertex(P1x, P1y);
-    P2x = VertexX - 1;
+    P2x = pos.x - 1;
     if(P2x < 0)
         P2x += myMap.width;
-    P2y = VertexY;
+    P2y = pos.y;
     P2 = &myMap.getVertex(P2x, P2y);
     P3 = Pmiddle;
     P1->flatVector = get_flatVector(*P1, *P2, *P3);
 
     // update second triangle right upside
-    P1x = VertexX + (even ? 0 : 1);
+    P1x = pos.x + (even ? 0 : 1);
     if(P1x >= myMap.width)
         P1x -= myMap.width;
-    P1y = VertexY - 1;
+    P1y = pos.y - 1;
     if(P1y < 0)
         P1y += myMap.height;
     P1 = &myMap.getVertex(P1x, P1y);
     P2 = Pmiddle;
-    P3x = VertexX + 1;
+    P3x = pos.x + 1;
     if(P3x >= myMap.width)
         P3x -= myMap.width;
-    P3y = VertexY;
+    P3y = pos.y;
     P3 = &myMap.getVertex(P3x, P3y);
     P1->flatVector = get_flatVector(*P1, *P2, *P3);
 
     // update third triangle down middle
     P1 = Pmiddle;
-    P2x = VertexX - (even ? 1 : 0);
+    P2x = pos.x - (even ? 1 : 0);
     if(P2x < 0)
         P2x += myMap.width;
-    P2y = VertexY + 1;
+    P2y = pos.y + 1;
     if(P2y >= myMap.height)
         P2y -= myMap.height;
     P2 = &myMap.getVertex(P2x, P2y);
-    P3x = VertexX + (even ? 0 : 1);
+    P3x = pos.x + (even ? 0 : 1);
     if(P3x >= myMap.width)
         P3x -= myMap.width;
-    P3y = VertexY + 1;
+    P3y = pos.y + 1;
     if(P3y >= myMap.height)
         P3y -= myMap.height;
     P3 = &myMap.getVertex(P3x, P3y);
     P1->flatVector = get_flatVector(*P1, *P2, *P3);
 }
 
-void CSurface::update_nodeVector(bobMAP& myMap, int VertexX, int VertexY)
+void CSurface::update_nodeVector(bobMAP& myMap, Position pos)
 {
-    int j = VertexY;
-    int i = VertexX;
+    int j = pos.y;
+    int i = pos.x;
     int width = myMap.width;
     int height = myMap.height;
 

--- a/CSurface.cpp
+++ b/CSurface.cpp
@@ -121,39 +121,39 @@ bool CSurface::Draw(SdlSurface& Surf_Dest, SdlSurface& Surf_Src, int X, int Y, i
     return Draw(Surf_Dest.get(), Surf_Src.get(), X, Y, angle);
 }
 
-bool CSurface::Draw(SDL_Surface* Surf_Dest, SDL_Surface* Surf_Src, int X, int Y, int X2, int Y2, int W, int H)
+bool CSurface::Draw(SDL_Surface* Surf_Dest, SDL_Surface* Surf_Src, Position dest, Extent srcOffset, Extent srcSize)
 {
     if(!Surf_Dest || !Surf_Src)
         return false;
 
     SDL_Rect DestR;
 
-    DestR.x = X;
-    DestR.y = Y;
+    DestR.x = dest.x;
+    DestR.y = dest.y;
 
     SDL_Rect SrcR;
 
-    SrcR.x = X2;
-    SrcR.y = Y2;
-    SrcR.w = W;
-    SrcR.h = H;
+    SrcR.x = static_cast<int>(srcOffset.x);
+    SrcR.y = static_cast<int>(srcOffset.y);
+    SrcR.w = static_cast<int>(srcSize.x);
+    SrcR.h = static_cast<int>(srcSize.y);
 
     SDL_BlitSurface(Surf_Src, &SrcR, Surf_Dest, &DestR);
 
     return true;
 }
 
-bool CSurface::Draw(SDL_Surface* Surf_Dest, SdlSurface& Surf_Src, int X, int Y, int X2, int Y2, int W, int H)
+bool CSurface::Draw(SDL_Surface* Surf_Dest, SdlSurface& Surf_Src, Position dest, Extent srcOffset, Extent srcSize)
 {
-    return Draw(Surf_Dest, Surf_Src.get(), X, Y, X2, Y2, W, H);
+    return Draw(Surf_Dest, Surf_Src.get(), dest, srcOffset, srcSize);
 }
 
 // this is the example function from the SDL-documentation to draw pixels
-void CSurface::DrawPixel_Color(SDL_Surface* screen, int x, int y, Uint32 color)
+void CSurface::DrawPixel_Color(SDL_Surface* screen, Position pos, Uint32 color)
 {
     int bpp = screen->format->BytesPerPixel;
     /* Here p is the address to the pixel we want to retrieve */
-    Uint8* p = (Uint8*)screen->pixels + y * screen->pitch + x * bpp;
+    Uint8* p = (Uint8*)screen->pixels + static_cast<int>(pos.y) * screen->pitch + static_cast<int>(pos.x) * bpp;
 
     if(SDL_MUSTLOCK(screen))
         SDL_LockSurface(screen);
@@ -186,21 +186,21 @@ void CSurface::DrawPixel_Color(SDL_Surface* screen, int x, int y, Uint32 color)
 }
 
 // this is the example function from the sdl-documentation to draw pixels
-void CSurface::DrawPixel_RGB(SDL_Surface* screen, int x, int y, Uint8 R, Uint8 G, Uint8 B)
+void CSurface::DrawPixel_RGB(SDL_Surface* screen, Position pos, Uint8 R, Uint8 G, Uint8 B)
 {
-    DrawPixel_Color(screen, x, y, SDL_MapRGB(screen->format, R, G, B));
+    DrawPixel_Color(screen, pos, SDL_MapRGB(screen->format, R, G, B));
 }
 
-void CSurface::DrawPixel_RGBA(SDL_Surface* screen, int x, int y, Uint8 R, Uint8 G, Uint8 B, Uint8 A)
+void CSurface::DrawPixel_RGBA(SDL_Surface* screen, Position pos, Uint8 R, Uint8 G, Uint8 B, Uint8 A)
 {
-    DrawPixel_Color(screen, x, y, SDL_MapRGBA(screen->format, R, G, B, A));
+    DrawPixel_Color(screen, pos, SDL_MapRGBA(screen->format, R, G, B, A));
 }
 
-Uint32 CSurface::GetPixel(SDL_Surface* surface, int x, int y)
+Uint32 CSurface::GetPixel(SDL_Surface* surface, Position pos)
 {
     int bpp = surface->format->BytesPerPixel;
     /* Here p is the address to the pixel we want to retrieve */
-    Uint8* p = (Uint8*)surface->pixels + y * surface->pitch + x * bpp;
+    Uint8* p = (Uint8*)surface->pixels + static_cast<int>(pos.y) * surface->pitch + static_cast<int>(pos.x) * bpp;
     switch(bpp)
     {
         case 1: return *p;

--- a/CSurface.h
+++ b/CSurface.h
@@ -24,21 +24,36 @@ public:
     // blits from source on destination to position X,Y and rotates (angle --> degrees --> 90, 180, 270)
     static bool Draw(SDL_Surface* Surf_Dest, SDL_Surface* Surf_Src, int X, int Y, int angle);
     static bool Draw(SdlSurface& Surf_Dest, SdlSurface& Surf_Src, int X, int Y, int angle);
-    // blits rectangle (X2,Y2,W,H) from source on destination to position X,Y
-    static bool Draw(SDL_Surface* Surf_Dest, SDL_Surface* Surf_Src, int X, int Y, int X2, int Y2, int W, int H);
-    static bool Draw(SDL_Surface* Surf_Dest, SdlSurface& Surf_Src, int X, int Y, int X2, int Y2, int W, int H);
+    // blits rectangle from source on destination
+    static bool Draw(SDL_Surface* Surf_Dest, SDL_Surface* Surf_Src, Position dest, Extent srcOffset, Extent srcSize);
+    static bool Draw(SDL_Surface* Surf_Dest, SdlSurface& Surf_Src, Position dest, Extent srcOffset, Extent srcSize);
+    static bool Draw(SdlSurface& Surf_Dest, SdlSurface& Surf_Src, Position dest, Extent srcOffset, Extent srcSize)
+    {
+        return Draw(Surf_Dest.get(), Surf_Src.get(), dest, srcOffset, srcSize);
+    }
+    // convenience overload for non-UI callers
+    static bool Draw(SDL_Surface* Surf_Dest, SDL_Surface* Surf_Src, int X, int Y, int X2, int Y2, int W, int H)
+    {
+        return Draw(Surf_Dest, Surf_Src, Position(X, Y), Extent(static_cast<unsigned>(X2), static_cast<unsigned>(Y2)),
+                    Extent(static_cast<unsigned>(W), static_cast<unsigned>(H)));
+    }
+    static bool Draw(SDL_Surface* Surf_Dest, SdlSurface& Surf_Src, int X, int Y, int X2, int Y2, int W, int H)
+    {
+        return Draw(Surf_Dest, Surf_Src.get(), X, Y, X2, Y2, W, H);
+    }
     static bool Draw(SdlSurface& Surf_Dest, SdlSurface& Surf_Src, int X, int Y, int X2, int Y2, int W, int H)
     {
         return Draw(Surf_Dest.get(), Surf_Src.get(), X, Y, X2, Y2, W, H);
     }
-    static void DrawPixel_Color(SDL_Surface* screen, int x, int y, Uint32 color);
-    static void DrawPixel_RGB(SDL_Surface* screen, int x, int y, Uint8 R, Uint8 G, Uint8 B);
-    static void DrawPixel_RGB(SdlSurface& screen, int x, int y, Uint8 R, Uint8 G, Uint8 B)
+
+    static void DrawPixel_Color(SDL_Surface* screen, Position pos, Uint32 color);
+    static void DrawPixel_RGB(SDL_Surface* screen, Position pos, Uint8 R, Uint8 G, Uint8 B);
+    static void DrawPixel_RGB(SdlSurface& screen, Position pos, Uint8 R, Uint8 G, Uint8 B)
     {
-        DrawPixel_RGB(screen.get(), x, y, R, G, B);
+        DrawPixel_RGB(screen.get(), pos, R, G, B);
     }
-    static void DrawPixel_RGBA(SDL_Surface* screen, int x, int y, Uint8 R, Uint8 G, Uint8 B, Uint8 A);
-    static Uint32 GetPixel(SDL_Surface* surface, int x, int y);
+    static void DrawPixel_RGBA(SDL_Surface* screen, Position pos, Uint8 R, Uint8 G, Uint8 B, Uint8 A);
+    static Uint32 GetPixel(SDL_Surface* surface, Position pos);
     static void DrawTriangleField(SDL_Surface* display, const DisplayRectangle& displayRect, const bobMAP& myMap);
     static void DrawTriangle(SDL_Surface* display, const DisplayRectangle& displayRect, const bobMAP& myMap,
                              MapType type, const MapNode& P1, const MapNode& P2, const MapNode& P3);

--- a/CSurface.h
+++ b/CSurface.h
@@ -44,7 +44,7 @@ public:
                              MapType type, const MapNode& P1, const MapNode& P2, const MapNode& P3);
 
     static void get_nodeVectors(bobMAP& myMap);
-    static void update_shading(bobMAP& myMap, int VertexX, int VertexY);
+    static void update_shading(bobMAP& myMap, Position pos);
 
 private:
     // to decide what to draw, triangle-textures or objects and texture-borders
@@ -56,9 +56,9 @@ private:
     static Sint32 get_LightIntensity(const vector& node);
     static float absf(float a);
     // update flatVectors around a vertex
-    static void update_flatVectors(bobMAP& myMap, int VertexX, int VertexY);
+    static void update_flatVectors(bobMAP& myMap, Position pos);
     // update nodeVector based on new flatVectors around it
-    static void update_nodeVector(bobMAP& myMap, int VertexX, int VertexY);
+    static void update_nodeVector(bobMAP& myMap, Position pos);
     static void GetTerrainTextureCoords(MapType mapType, TriangleTerrainType texture, bool isRSU, int texture_move,
                                         Point16& upper, Point16& left, Point16& right, Point16& upper2, Point16& left2,
                                         Point16& right2);

--- a/CSurface.h
+++ b/CSurface.h
@@ -25,16 +25,16 @@ public:
     static bool Draw(SDL_Surface* Surf_Dest, SDL_Surface* Surf_Src, int X, int Y, int angle);
     static bool Draw(SdlSurface& Surf_Dest, SdlSurface& Surf_Src, int X, int Y, int angle);
     // blits rectangle from source on destination
-    static bool Draw(SDL_Surface* Surf_Dest, SDL_Surface* Surf_Src, Position dest, Extent srcOffset, Extent srcSize);
-    static bool Draw(SDL_Surface* Surf_Dest, SdlSurface& Surf_Src, Position dest, Extent srcOffset, Extent srcSize);
-    static bool Draw(SdlSurface& Surf_Dest, SdlSurface& Surf_Src, Position dest, Extent srcOffset, Extent srcSize)
+    static bool Draw(SDL_Surface* Surf_Dest, SDL_Surface* Surf_Src, Position dest, Position srcOffset, Extent srcSize);
+    static bool Draw(SDL_Surface* Surf_Dest, SdlSurface& Surf_Src, Position dest, Position srcOffset, Extent srcSize);
+    static bool Draw(SdlSurface& Surf_Dest, SdlSurface& Surf_Src, Position dest, Position srcOffset, Extent srcSize)
     {
         return Draw(Surf_Dest.get(), Surf_Src.get(), dest, srcOffset, srcSize);
     }
     // convenience overload for non-UI callers
     static bool Draw(SDL_Surface* Surf_Dest, SDL_Surface* Surf_Src, int X, int Y, int X2, int Y2, int W, int H)
     {
-        return Draw(Surf_Dest, Surf_Src, Position(X, Y), Extent(static_cast<unsigned>(X2), static_cast<unsigned>(Y2)),
+        return Draw(Surf_Dest, Surf_Src, Position(X, Y), Position(X2, Y2),
                     Extent(static_cast<unsigned>(W), static_cast<unsigned>(H)));
     }
     static bool Draw(SDL_Surface* Surf_Dest, SdlSurface& Surf_Src, int X, int Y, int X2, int Y2, int W, int H)

--- a/callbacks.cpp
+++ b/callbacks.cpp
@@ -239,21 +239,21 @@ void callback::submenuOptions(int Param)
         case INITIALIZING_CALL:
             SubMenu = global::s2->RegisterMenu(std::make_unique<CMenu>(SPLASHSCREEN_SUBMENU3));
             // add button for "back to main menu"
-            SubMenu->addButton(submenuOptions, MAINMENU, Point16(static_cast<int>(global::s2->GameResolution.x / 2 - 100), 440),
+            SubMenu->addButton(submenuOptions, MAINMENU, Point16(global::s2->GameResolution.x / 2 - 100, 440),
                                Extent16(200, 20), BUTTON_RED1, "back");
             // add menu title
-            SubMenu->addText("Options", Point16(static_cast<int>(global::s2->GameResolution.x / 2 - 20), 10), FontSize::Large);
+            SubMenu->addText("Options", Point16(global::s2->GameResolution.x / 2 - 20, 10), FontSize::Large);
             // add screen resolution
             if(TextResolution)
                 SubMenu->delText(TextResolution);
             TextResolution = SubMenu->addText(
               helpers::format("Game Resolution: %d*%d / %s", global::s2->GameResolution.x, global::s2->GameResolution.y,
                               (global::s2->fullscreen ? "Fullscreen" : "Window")),
-              Point16(static_cast<int>(global::s2->GameResolution.x / 2 - 110), 50), FontSize::Medium);
+              Point16(global::s2->GameResolution.x / 2 - 110, 50), FontSize::Medium);
             if(ButtonFullscreen)
                 SubMenu->delButton(ButtonFullscreen);
             ButtonFullscreen = SubMenu->addButton(
-              submenuOptions, FULLSCREEN, Point16(static_cast<int>(global::s2->GameResolution.x / 2 - 100), 190),
+              submenuOptions, FULLSCREEN, Point16(global::s2->GameResolution.x / 2 - 100, 190),
               Extent16(200, 20), BUTTON_RED1, (global::s2->fullscreen ? "WINDOW" : "FULLSCREEN"));
             SelectBoxRes = SubMenu->addSelectBox(ButtonFullscreen->getPos() - Point16(0, 120), Extent16(200, 110),
                                                  FontSize::Medium, FontColor::Yellow, BUTTON_GREY);

--- a/callbacks.cpp
+++ b/callbacks.cpp
@@ -252,9 +252,9 @@ void callback::submenuOptions(int Param)
               Point16(global::s2->GameResolution.x / 2 - 110, 50), FontSize::Medium);
             if(ButtonFullscreen)
                 SubMenu->delButton(ButtonFullscreen);
-            ButtonFullscreen = SubMenu->addButton(
-              submenuOptions, FULLSCREEN, Point16(global::s2->GameResolution.x / 2 - 100, 190),
-              Extent16(200, 20), BUTTON_RED1, (global::s2->fullscreen ? "WINDOW" : "FULLSCREEN"));
+            ButtonFullscreen =
+              SubMenu->addButton(submenuOptions, FULLSCREEN, Point16(global::s2->GameResolution.x / 2 - 100, 190),
+                                 Extent16(200, 20), BUTTON_RED1, (global::s2->fullscreen ? "WINDOW" : "FULLSCREEN"));
             SelectBoxRes = SubMenu->addSelectBox(ButtonFullscreen->getPos() - Point16(0, 120), Extent16(200, 110),
                                                  FontSize::Medium, FontColor::Yellow, BUTTON_GREY);
             SelectBoxRes->addOption("800 x 600 (SVGA)", submenuOptions, SELECTBOX_800_600);

--- a/callbacks.cpp
+++ b/callbacks.cpp
@@ -142,9 +142,11 @@ void callback::mainmenu(int Param)
             MainMenu = global::s2->RegisterMenu(std::make_unique<CMenu>(SPLASHSCREEN_MAINMENU));
             MainMenu->addButton(mainmenu, ENDGAME, Point16(50, 400), Extent16(200, 20), BUTTON_RED1, "Quit program");
 #ifdef _ADMINMODE
-            MainMenu->addButton(submenu1, INITIALIZING_CALL, Point16(50, 200), Extent16(200, 20), BUTTON_GREY, "Submenu_1");
+            MainMenu->addButton(submenu1, INITIALIZING_CALL, Point16(50, 200), Extent16(200, 20), BUTTON_GREY,
+                                "Submenu_1");
 #endif
-            MainMenu->addButton(mainmenu, STARTEDITOR, Point16(50, 160), Extent16(200, 20), BUTTON_RED1, "Start editor");
+            MainMenu->addButton(mainmenu, STARTEDITOR, Point16(50, 160), Extent16(200, 20), BUTTON_RED1,
+                                "Start editor");
             MainMenu->addButton(mainmenu, OPTIONS, Point16(50, 370), Extent16(200, 20), BUTTON_GREEN2, "Options");
             break;
 
@@ -250,9 +252,9 @@ void callback::submenuOptions(int Param)
               Point16((int)(global::s2->GameResolution.x / 2 - 110), 50), FontSize::Medium);
             if(ButtonFullscreen)
                 SubMenu->delButton(ButtonFullscreen);
-            ButtonFullscreen =
-              SubMenu->addButton(submenuOptions, FULLSCREEN, Point16((int)(global::s2->GameResolution.x / 2 - 100), 190),
-                                 Extent16(200, 20), BUTTON_RED1, (global::s2->fullscreen ? "WINDOW" : "FULLSCREEN"));
+            ButtonFullscreen = SubMenu->addButton(
+              submenuOptions, FULLSCREEN, Point16((int)(global::s2->GameResolution.x / 2 - 100), 190),
+              Extent16(200, 20), BUTTON_RED1, (global::s2->fullscreen ? "WINDOW" : "FULLSCREEN"));
             SelectBoxRes = SubMenu->addSelectBox(ButtonFullscreen->getPos() - Point16(0, 120), Extent16(200, 110),
                                                  FontSize::Medium, FontColor::Yellow, BUTTON_GREY);
             SelectBoxRes->addOption("800 x 600 (SVGA)", submenuOptions, SELECTBOX_800_600);
@@ -716,7 +718,8 @@ void callback::EditorMainMenu(int Param)
             WNDMain->addButton(EditorMainMenu, LOADMENU, Point16(8, 100), Extent16(190, 20), BUTTON_GREEN2, "Load map");
             WNDMain->addButton(EditorMainMenu, SAVEMENU, Point16(8, 125), Extent16(190, 20), BUTTON_GREEN2, "Save map");
 
-            WNDMain->addButton(EditorMainMenu, QUITMENU, Point16(8, 260), Extent16(190, 20), BUTTON_GREEN2, "Leave editor");
+            WNDMain->addButton(EditorMainMenu, QUITMENU, Point16(8, 260), Extent16(190, 20), BUTTON_GREEN2,
+                               "Leave editor");
             break;
 
         case WINDOWQUIT:
@@ -866,7 +869,8 @@ void callback::EditorSaveMenu(int Param)
                 TXTF_Author = WNDSave->addTextfield(Point16(10, 87), 19, 1);
                 TXTF_Author->setText(MapObj->getAuthor());
                 WNDSave->addButton(EditorSaveMenu, SAVEMAP, Point16(170, 120), Extent16(90, 20), BUTTON_GREY, "Save");
-                WNDSave->addButton(EditorSaveMenu, WINDOWQUIT, Point16(170, 145), Extent16(90, 20), BUTTON_RED1, "Abort");
+                WNDSave->addButton(EditorSaveMenu, WINDOWQUIT, Point16(170, 145), Extent16(90, 20), BUTTON_RED1,
+                                   "Abort");
                 break;
             }
         case WINDOWQUIT:
@@ -923,8 +927,10 @@ void callback::EditorQuitMenu(int Param)
                 break;
             WNDBackToMainMenu = global::s2->RegisterWindow(
               std::make_unique<CWindow>(EditorQuitMenu, WINDOWQUIT, WindowPos::Center, Extent(212, 110), "Exit?"));
-            WNDBackToMainMenu->addButton(EditorQuitMenu, BACKTOMAIN, Point16(0, 0), Extent16(100, 80), BUTTON_GREEN2, nullptr, PICTURE_SMALL_TICK);
-            WNDBackToMainMenu->addButton(EditorQuitMenu, NOTBACKTOMAIN, Point16(100, 0), Extent16(100, 80), BUTTON_RED1, nullptr, PICTURE_SMALL_CROSS);
+            WNDBackToMainMenu->addButton(EditorQuitMenu, BACKTOMAIN, Point16(0, 0), Extent16(100, 80), BUTTON_GREEN2,
+                                         nullptr, PICTURE_SMALL_TICK);
+            WNDBackToMainMenu->addButton(EditorQuitMenu, NOTBACKTOMAIN, Point16(100, 0), Extent16(100, 80), BUTTON_RED1,
+                                         nullptr, PICTURE_SMALL_CROSS);
             break;
 
         case BACKTOMAIN:
@@ -1435,35 +1441,46 @@ void callback::EditorLandscapeMenu(int Param)
             {
                 case MAP_GREENLAND:
                     WNDLandscape->addPicture(EditorLandscapeMenu, PICGRANITE, Point16(2, 2), PICTURE_LANDSCAPE_GRANITE);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICTREEDEAD, Point16(36, 2), PICTURE_LANDSCAPE_TREE_DEAD);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICTREEDEAD, Point16(36, 2),
+                                             PICTURE_LANDSCAPE_TREE_DEAD);
                     WNDLandscape->addPicture(EditorLandscapeMenu, PICSTONE, Point16(70, 2), PICTURE_LANDSCAPE_STONE);
                     WNDLandscape->addPicture(EditorLandscapeMenu, PICCACTUS, Point16(2, 36), PICTURE_LANDSCAPE_CACTUS);
                     WNDLandscape->addPicture(EditorLandscapeMenu, PICPEBBLE, Point16(36, 36), PICTURE_LANDSCAPE_PEBBLE);
                     WNDLandscape->addPicture(EditorLandscapeMenu, PICBUSH, Point16(70, 36), PICTURE_LANDSCAPE_BUSH);
                     WNDLandscape->addPicture(EditorLandscapeMenu, PICSHRUB, Point16(2, 70), PICTURE_LANDSCAPE_SHRUB);
                     WNDLandscape->addPicture(EditorLandscapeMenu, PICBONE, Point16(36, 70), PICTURE_LANDSCAPE_BONE);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICMUSHROOM, Point16(70, 70), PICTURE_LANDSCAPE_MUSHROOM);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICMUSHROOM, Point16(70, 70),
+                                             PICTURE_LANDSCAPE_MUSHROOM);
                     WNDLandscape->addPicture(EditorLandscapeMenu, PICFLOWERS, Point16(5, 107), MAPPIC_FLOWERS);
                     break;
                 case MAP_WASTELAND:
                     WNDLandscape->addPicture(EditorLandscapeMenu, PICGRANITE, Point16(2, 2), PICTURE_LANDSCAPE_GRANITE);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICTREEDEAD, Point16(36, 2), PICTURE_LANDSCAPE_TREE_DEAD);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICTREEDEAD, Point16(36, 2),
+                                             PICTURE_LANDSCAPE_TREE_DEAD);
                     WNDLandscape->addPicture(EditorLandscapeMenu, PICSTONE, Point16(70, 2), PICTURE_LANDSCAPE_STONE);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSTALAGMITE, Point16(2, 36), PICTURE_LANDSCAPE_STALAGMITE);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSTALAGMITE, Point16(2, 36),
+                                             PICTURE_LANDSCAPE_STALAGMITE);
                     WNDLandscape->addPicture(EditorLandscapeMenu, PICPEBBLE, Point16(36, 36), PICTURE_LANDSCAPE_PEBBLE);
                     WNDLandscape->addPicture(EditorLandscapeMenu, PICBUSH, Point16(70, 36), PICTURE_LANDSCAPE_BUSH);
                     WNDLandscape->addPicture(EditorLandscapeMenu, PICSHRUB, Point16(2, 70), PICTURE_LANDSCAPE_SHRUB);
                     WNDLandscape->addPicture(EditorLandscapeMenu, PICBONE, Point16(36, 70), PICTURE_LANDSCAPE_BONE);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICMUSHROOM, Point16(70, 70), PICTURE_LANDSCAPE_MUSHROOM);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICMUSHROOM, Point16(70, 70),
+                                             PICTURE_LANDSCAPE_MUSHROOM);
                     WNDLandscape->addPicture(EditorLandscapeMenu, PICFLOWERS, Point16(5, 107), MAPPIC_FLOWERS);
                     break;
                 case MAP_WINTERLAND:
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICGRANITE, Point16(2, 2), PICTURE_LANDSCAPE_GRANITE_WINTER);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICTREEDEAD, Point16(36, 2), PICTURE_LANDSCAPE_TREE_DEAD_WINTER);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSTONE, Point16(70, 2), PICTURE_LANDSCAPE_STONE_WINTER);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICPEBBLE, Point16(2, 36), PICTURE_LANDSCAPE_PEBBLE_WINTER);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICBONE, Point16(36, 36), PICTURE_LANDSCAPE_BONE_WINTER);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICMUSHROOM, Point16(70, 36), PICTURE_LANDSCAPE_MUSHROOM_WINTER);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICGRANITE, Point16(2, 2),
+                                             PICTURE_LANDSCAPE_GRANITE_WINTER);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICTREEDEAD, Point16(36, 2),
+                                             PICTURE_LANDSCAPE_TREE_DEAD_WINTER);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSTONE, Point16(70, 2),
+                                             PICTURE_LANDSCAPE_STONE_WINTER);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICPEBBLE, Point16(2, 36),
+                                             PICTURE_LANDSCAPE_PEBBLE_WINTER);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICBONE, Point16(36, 36),
+                                             PICTURE_LANDSCAPE_BONE_WINTER);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICMUSHROOM, Point16(70, 36),
+                                             PICTURE_LANDSCAPE_MUSHROOM_WINTER);
                     WNDLandscape->addPicture(EditorLandscapeMenu, PICFLOWERS, Point16(73, 73), MAPPIC_FLOWERS);
                     break;
                 default: // should not happen
@@ -1844,8 +1861,10 @@ void callback::EditorCursorMenu(int Param)
                                         WINDOW_CLOSE | WINDOW_MINIMIZE | WINDOW_MOVE));
             MapObj = global::s2->getMapObj();
 
-            CursorModeButton = WNDCursor->addButton(EditorCursorMenu, CURSORMODE, Point16(2, 2), Extent16(96, 32), BUTTON_GREY, "Hexagon");
-            CursorRandomButton = WNDCursor->addButton(EditorCursorMenu, CURSORRANDOM, Point16(2, 34), Extent16(196, 32), BUTTON_GREY, "Cursor-Activity: static");
+            CursorModeButton = WNDCursor->addButton(EditorCursorMenu, CURSORMODE, Point16(2, 2), Extent16(96, 32),
+                                                    BUTTON_GREY, "Hexagon");
+            CursorRandomButton = WNDCursor->addButton(EditorCursorMenu, CURSORRANDOM, Point16(2, 34), Extent16(196, 32),
+                                                      BUTTON_GREY, "Cursor-Activity: static");
             WNDCursor->addButton(EditorCursorMenu, TRIANGLE, Point16(2, 66), Extent16(32, 32), BUTTON_GREY, nullptr);
             trianglePictureArrowUp = WNDCursor->addStaticPicture(Point16(8, 74), CURSOR_SYMBOL_ARROW_UP);
             trianglePictureArrowDown = WNDCursor->addStaticPicture(Point16(17, 77), CURSOR_SYMBOL_ARROW_DOWN);
@@ -1928,13 +1947,13 @@ void callback::EditorCursorMenu(int Param)
             }
             if(MapObj->getHexagonMode())
             {
-                CursorModeButton =
-                  WNDCursor->addButton(EditorCursorMenu, CURSORMODE, Point16(2, 2), Extent16(96, 32), BUTTON_GREY, "Square");
+                CursorModeButton = WNDCursor->addButton(EditorCursorMenu, CURSORMODE, Point16(2, 2), Extent16(96, 32),
+                                                        BUTTON_GREY, "Square");
                 MapObj->setHexagonMode(false);
             } else
             {
-                CursorModeButton =
-                  WNDCursor->addButton(EditorCursorMenu, CURSORMODE, Point16(2, 2), Extent16(96, 32), BUTTON_GREY, "Hexagon");
+                CursorModeButton = WNDCursor->addButton(EditorCursorMenu, CURSORMODE, Point16(2, 2), Extent16(96, 32),
+                                                        BUTTON_GREY, "Hexagon");
                 MapObj->setHexagonMode(true);
             }
             break;
@@ -1946,11 +1965,13 @@ void callback::EditorCursorMenu(int Param)
             }
             if(MapObj->getVertexActivityRandom())
             {
-                CursorRandomButton = WNDCursor->addButton(EditorCursorMenu, CURSORRANDOM, Point16(2, 34), Extent16(196, 32), BUTTON_GREY, "Cursor-Activity: static");
+                CursorRandomButton = WNDCursor->addButton(EditorCursorMenu, CURSORRANDOM, Point16(2, 34),
+                                                          Extent16(196, 32), BUTTON_GREY, "Cursor-Activity: static");
                 MapObj->setVertexActivityRandom(false);
             } else
             {
-                CursorRandomButton = WNDCursor->addButton(EditorCursorMenu, CURSORRANDOM, Point16(2, 34), Extent16(196, 32), BUTTON_GREY, "Cursor-Activity: random");
+                CursorRandomButton = WNDCursor->addButton(EditorCursorMenu, CURSORRANDOM, Point16(2, 34),
+                                                          Extent16(196, 32), BUTTON_GREY, "Cursor-Activity: random");
                 MapObj->setVertexActivityRandom(true);
             }
             break;
@@ -2041,42 +2062,62 @@ void callback::EditorCreateMenu(int Param)
             MapObj = global::s2->getMapObj();
 
             WNDCreate->addText("Width", Point16(95, 4), FontSize::Small, FontColor::Yellow);
-            WNDCreate->addButton(EditorCreateMenu, REDUCE_WIDTH_128, Point16(0, 15), Extent16(35, 20), BUTTON_GREY, "128<-");
-            WNDCreate->addButton(EditorCreateMenu, REDUCE_WIDTH_16, Point16(35, 15), Extent16(35, 20), BUTTON_GREY, "16<-");
-            WNDCreate->addButton(EditorCreateMenu, REDUCE_WIDTH_2, Point16(70, 15), Extent16(25, 20), BUTTON_GREY, "2<-");
+            WNDCreate->addButton(EditorCreateMenu, REDUCE_WIDTH_128, Point16(0, 15), Extent16(35, 20), BUTTON_GREY,
+                                 "128<-");
+            WNDCreate->addButton(EditorCreateMenu, REDUCE_WIDTH_16, Point16(35, 15), Extent16(35, 20), BUTTON_GREY,
+                                 "16<-");
+            WNDCreate->addButton(EditorCreateMenu, REDUCE_WIDTH_2, Point16(70, 15), Extent16(25, 20), BUTTON_GREY,
+                                 "2<-");
             TextWidth = WNDCreate->addText(std::to_string(width), Point16(105, 17), FontSize::Large, FontColor::Yellow);
-            WNDCreate->addButton(EditorCreateMenu, RAISE_WIDTH_2, Point16(143, 15), Extent16(25, 20), BUTTON_GREY, "->2");
-            WNDCreate->addButton(EditorCreateMenu, RAISE_WIDTH_16, Point16(168, 15), Extent16(35, 20), BUTTON_GREY, "->16");
-            WNDCreate->addButton(EditorCreateMenu, RAISE_WIDTH_128, Point16(203, 15), Extent16(35, 20), BUTTON_GREY, "->128");
+            WNDCreate->addButton(EditorCreateMenu, RAISE_WIDTH_2, Point16(143, 15), Extent16(25, 20), BUTTON_GREY,
+                                 "->2");
+            WNDCreate->addButton(EditorCreateMenu, RAISE_WIDTH_16, Point16(168, 15), Extent16(35, 20), BUTTON_GREY,
+                                 "->16");
+            WNDCreate->addButton(EditorCreateMenu, RAISE_WIDTH_128, Point16(203, 15), Extent16(35, 20), BUTTON_GREY,
+                                 "->128");
 
             WNDCreate->addText("Height", Point16(100, 40), FontSize::Small, FontColor::Yellow);
-            WNDCreate->addButton(EditorCreateMenu, REDUCE_HEIGHT_128, Point16(0, 49), Extent16(35, 20), BUTTON_GREY, "128<-");
-            WNDCreate->addButton(EditorCreateMenu, REDUCE_HEIGHT_16, Point16(35, 49), Extent16(35, 20), BUTTON_GREY, "16<-");
-            WNDCreate->addButton(EditorCreateMenu, REDUCE_HEIGHT_2, Point16(70, 49), Extent16(25, 20), BUTTON_GREY, "2<-");
-            TextHeight = WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
-            WNDCreate->addButton(EditorCreateMenu, RAISE_HEIGHT_2, Point16(143, 49), Extent16(25, 20), BUTTON_GREY, "->2");
-            WNDCreate->addButton(EditorCreateMenu, RAISE_HEIGHT_16, Point16(168, 49), Extent16(35, 20), BUTTON_GREY, "->16");
-            WNDCreate->addButton(EditorCreateMenu, RAISE_HEIGHT_128, Point16(203, 49), Extent16(35, 20), BUTTON_GREY, "->128");
+            WNDCreate->addButton(EditorCreateMenu, REDUCE_HEIGHT_128, Point16(0, 49), Extent16(35, 20), BUTTON_GREY,
+                                 "128<-");
+            WNDCreate->addButton(EditorCreateMenu, REDUCE_HEIGHT_16, Point16(35, 49), Extent16(35, 20), BUTTON_GREY,
+                                 "16<-");
+            WNDCreate->addButton(EditorCreateMenu, REDUCE_HEIGHT_2, Point16(70, 49), Extent16(25, 20), BUTTON_GREY,
+                                 "2<-");
+            TextHeight =
+              WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
+            WNDCreate->addButton(EditorCreateMenu, RAISE_HEIGHT_2, Point16(143, 49), Extent16(25, 20), BUTTON_GREY,
+                                 "->2");
+            WNDCreate->addButton(EditorCreateMenu, RAISE_HEIGHT_16, Point16(168, 49), Extent16(35, 20), BUTTON_GREY,
+                                 "->16");
+            WNDCreate->addButton(EditorCreateMenu, RAISE_HEIGHT_128, Point16(203, 49), Extent16(35, 20), BUTTON_GREY,
+                                 "->128");
 
             WNDCreate->addText("Landscape", Point16(85, 80), FontSize::Small, FontColor::Yellow);
-            ButtonLandscape = WNDCreate->addButton(EditorCreateMenu, CHANGE_LANDSCAPE, Point16(64, 93), Extent16(110, 20), BUTTON_GREY, (LandscapeType == 0 ? "Greenland" : (LandscapeType == 1 ? "Wasteland" : "Winterworld")));
+            ButtonLandscape = WNDCreate->addButton(
+              EditorCreateMenu, CHANGE_LANDSCAPE, Point16(64, 93), Extent16(110, 20), BUTTON_GREY,
+              (LandscapeType == 0 ? "Greenland" : (LandscapeType == 1 ? "Wasteland" : "Winterworld")));
 
             WNDCreate->addText("Main area", Point16(82, 120), FontSize::Small, FontColor::Yellow);
-            WNDCreate->addButton(EditorCreateMenu, TEXTURE_PREVIOUS, Point16(45, 139), Extent16(35, 20), BUTTON_GREY, "-");
+            WNDCreate->addButton(EditorCreateMenu, TEXTURE_PREVIOUS, Point16(45, 139), Extent16(35, 20), BUTTON_GREY,
+                                 "-");
             PicTextureIndex = WNDCreate->addStaticPicture(Point16(102, 133), PicTextureIndexGlobal);
             WNDCreate->addButton(EditorCreateMenu, TEXTURE_NEXT, Point16(158, 139), Extent16(35, 20), BUTTON_GREY, "+");
 
             WNDCreate->addText("Border size", Point16(103, 175), FontSize::Small, FontColor::Yellow);
             WNDCreate->addButton(EditorCreateMenu, REDUCE_BORDER, Point16(45, 186), Extent16(35, 20), BUTTON_GREY, "-");
-            TextBorder = WNDCreate->addText(std::to_string(border), Point16(112, 188), FontSize::Large, FontColor::Yellow);
+            TextBorder =
+              WNDCreate->addText(std::to_string(border), Point16(112, 188), FontSize::Large, FontColor::Yellow);
             WNDCreate->addButton(EditorCreateMenu, RAISE_BORDER, Point16(158, 186), Extent16(35, 20), BUTTON_GREY, "+");
 
             WNDCreate->addText("Border area", Point16(65, 215), FontSize::Small, FontColor::Yellow);
-            WNDCreate->addButton(EditorCreateMenu, BORDER_TEXTURE_PREVIOUS, Point16(45, 234), Extent16(35, 20), BUTTON_GREY, "-");
+            WNDCreate->addButton(EditorCreateMenu, BORDER_TEXTURE_PREVIOUS, Point16(45, 234), Extent16(35, 20),
+                                 BUTTON_GREY, "-");
             PicBorderTextureIndex = WNDCreate->addStaticPicture(Point16(102, 228), PicBorderTextureIndexGlobal);
-            WNDCreate->addButton(EditorCreateMenu, BORDER_TEXTURE_NEXT, Point16(158, 234), Extent16(35, 20), BUTTON_GREY, "+");
+            WNDCreate->addButton(EditorCreateMenu, BORDER_TEXTURE_NEXT, Point16(158, 234), Extent16(35, 20),
+                                 BUTTON_GREY, "+");
 
-            WNDCreate->addButton(EditorCreateMenu, CREATE_WORLD, Point16(44, 275), Extent16(150, 40), BUTTON_GREY, "Create world");
+            WNDCreate->addButton(EditorCreateMenu, CREATE_WORLD, Point16(44, 275), Extent16(150, 40), BUTTON_GREY,
+                                 "Create world");
             break;
 
         case CALL_FROM_GAMELOOP: break;
@@ -2135,7 +2176,8 @@ void callback::EditorCreateMenu(int Param)
             else
                 height = 32;
             WNDCreate->delText(TextHeight);
-            TextHeight = WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
+            TextHeight =
+              WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
             break;
         case REDUCE_HEIGHT_16:
             if(height - 16 >= 32)
@@ -2143,7 +2185,8 @@ void callback::EditorCreateMenu(int Param)
             else
                 height = 32;
             WNDCreate->delText(TextHeight);
-            TextHeight = WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
+            TextHeight =
+              WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
             break;
         case REDUCE_HEIGHT_2:
             if(height - 2 >= 32)
@@ -2151,7 +2194,8 @@ void callback::EditorCreateMenu(int Param)
             else
                 height = 32;
             WNDCreate->delText(TextHeight);
-            TextHeight = WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
+            TextHeight =
+              WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
             break;
         case RAISE_HEIGHT_2:
             if(height + 2 <= MAXMAPHEIGHT)
@@ -2159,7 +2203,8 @@ void callback::EditorCreateMenu(int Param)
             else
                 height = MAXMAPHEIGHT;
             WNDCreate->delText(TextHeight);
-            TextHeight = WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
+            TextHeight =
+              WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
             break;
         case RAISE_HEIGHT_16:
             if(height + 16 <= MAXMAPHEIGHT)
@@ -2167,7 +2212,8 @@ void callback::EditorCreateMenu(int Param)
             else
                 height = MAXMAPHEIGHT;
             WNDCreate->delText(TextHeight);
-            TextHeight = WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
+            TextHeight =
+              WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
             break;
         case RAISE_HEIGHT_128:
             if(height + 128 <= MAXMAPHEIGHT)
@@ -2175,7 +2221,8 @@ void callback::EditorCreateMenu(int Param)
             else
                 height = MAXMAPHEIGHT;
             WNDCreate->delText(TextHeight);
-            TextHeight = WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
+            TextHeight =
+              WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
             break;
 
         case CHANGE_LANDSCAPE:
@@ -2183,7 +2230,9 @@ void callback::EditorCreateMenu(int Param)
             if(LandscapeType > 2)
                 LandscapeType = 0;
             WNDCreate->delButton(ButtonLandscape);
-            ButtonLandscape = WNDCreate->addButton(EditorCreateMenu, CHANGE_LANDSCAPE, Point16(64, 93), Extent16(110, 20), BUTTON_GREY, (LandscapeType == 0 ? "Greenland" : (LandscapeType == 1 ? "Wasteland" : "Winterworld")));
+            ButtonLandscape = WNDCreate->addButton(
+              EditorCreateMenu, CHANGE_LANDSCAPE, Point16(64, 93), Extent16(110, 20), BUTTON_GREY,
+              (LandscapeType == 0 ? "Greenland" : (LandscapeType == 1 ? "Wasteland" : "Winterworld")));
             switch(LandscapeType)
             {
                 case 0:
@@ -2414,12 +2463,14 @@ void callback::EditorCreateMenu(int Param)
         case REDUCE_BORDER:
             border = std::max(0, border - 1);
             WNDCreate->delText(TextBorder);
-            TextBorder = WNDCreate->addText(std::to_string(border), Point16(112, 188), FontSize::Large, FontColor::Yellow);
+            TextBorder =
+              WNDCreate->addText(std::to_string(border), Point16(112, 188), FontSize::Large, FontColor::Yellow);
             break;
         case RAISE_BORDER:
             border = std::min(12, border + 1);
             WNDCreate->delText(TextBorder);
-            TextBorder = WNDCreate->addText(std::to_string(border), Point16(112, 188), FontSize::Large, FontColor::Yellow);
+            TextBorder =
+              WNDCreate->addText(std::to_string(border), Point16(112, 188), FontSize::Large, FontColor::Yellow);
             break;
 
         case BORDER_TEXTURE_PREVIOUS:
@@ -2965,11 +3016,17 @@ void callback::submenu1(int Param)
         case INITIALIZING_CALL:
             SubMenu = global::s2->RegisterMenu(std::make_unique<CMenu>(SPLASHSCREEN_SUBMENU1));
             SubMenu->addButton(submenu1, MAINMENU, Point16(400, 440), Extent16(200, 20), BUTTON_RED1, "back");
-            greatMoon = SubMenu->addButton(submenu1, GREATMOON, Point16(100, 100), Extent16(200, 200), BUTTON_STONE, nullptr, MOON);
+            greatMoon = SubMenu->addButton(submenu1, GREATMOON, Point16(100, 100), Extent16(200, 200), BUTTON_STONE,
+                                           nullptr, MOON);
             greatMoon->setMotionParams(GREATMOONENTRY, GREATMOONLEAVE);
-            SubMenu->addButton(submenu1, SMALLMOON, Point16(100, 350), Extent16(global::bmpArray[MOON].w, global::bmpArray[MOON].h), BUTTON_STONE, nullptr, MOON);
-            SubMenu->addButton(submenu1, TOOSMALL, Point16(100, 400), Extent16(global::bmpArray[MOON].w - 1, global::bmpArray[MOON].h - 1), BUTTON_STONE, nullptr, MOON);
-            SubMenu->addButton(submenu1, CREATEWINDOW, Point16(500, 10), Extent16(130, 30), BUTTON_GREEN1, "Create window");
+            SubMenu->addButton(submenu1, SMALLMOON, Point16(100, 350),
+                               Extent16(global::bmpArray[MOON].w, global::bmpArray[MOON].h), BUTTON_STONE, nullptr,
+                               MOON);
+            SubMenu->addButton(submenu1, TOOSMALL, Point16(100, 400),
+                               Extent16(global::bmpArray[MOON].w - 1, global::bmpArray[MOON].h - 1), BUTTON_STONE,
+                               nullptr, MOON);
+            SubMenu->addButton(submenu1, CREATEWINDOW, Point16(500, 10), Extent16(130, 30), BUTTON_GREEN1,
+                               "Create window");
             picObject = SubMenu->addPicture(submenu1, PICOBJECT, Point16(200, 30), MIS0BOBS_SHIP);
             picObject->setMotionParams(PICOBJECTENTRY, PICOBJECTLEAVE);
             // text block with \n
@@ -3010,7 +3067,9 @@ void callback::submenu1(int Param)
 
         case GREATMOON:
             SubMenu->addText("Title!", Point16(300, 10), FontSize::Large);
-            SubMenu->addText(helpers::format("Window X: %d Window Y: %d", global::s2->GameResolution.x, global::s2->GameResolution.y), Point16(10, 10), FontSize::Large);
+            SubMenu->addText(
+              helpers::format("Window X: %d Window Y: %d", global::s2->GameResolution.x, global::s2->GameResolution.y),
+              Point16(10, 10), FontSize::Large);
             break;
 
         case SMALLMOON:
@@ -3031,8 +3090,10 @@ void callback::submenu1(int Param)
                   submenu1, TESTWINDOWQUITMESSAGE, Position(5, 5), Extent(350, 240), "Window", WINDOW_GREEN1,
                   WINDOW_CLOSE | WINDOW_MOVE | WINDOW_MINIMIZE | WINDOW_RESIZE));
                 testWindow->addText("Text inside the window", Point16(10, 10), FontSize::Large);
-                testWindow->addButton(submenu1, -10, Point16(150, 100), Extent16(210, 30), BUTTON_GREEN2, "Button inside the window");
-                testWindowPicture = testWindow->addPicture(submenu1, TESTWINDOWPICTURE, Point16(10, 60), MIS2BOBS_FORTRESS);
+                testWindow->addButton(submenu1, -10, Point16(150, 100), Extent16(210, 30), BUTTON_GREEN2,
+                                      "Button inside the window");
+                testWindowPicture =
+                  testWindow->addPicture(submenu1, TESTWINDOWPICTURE, Point16(10, 60), MIS2BOBS_FORTRESS);
                 testWindowPicture->setMotionParams(TESTWINDOWPICTUREENTRY, TESTWINDOWPICTURELEAVE);
                 testTextfield_testWindow =
                   testWindow->addTextfield(Point16(130, 30), 10, 3, FontSize::Large, FontColor::Red, BUTTON_GREY, true);
@@ -3136,7 +3197,8 @@ void callback::submenu1(int Param)
                 }
                 if(!counterText)
                 {
-                    counterText = SubMenu->addText(helpers::format("counter: %d", counter), Point16(100, 20), FontSize::Small);
+                    counterText =
+                      SubMenu->addText(helpers::format("counter: %d", counter), Point16(100, 20), FontSize::Small);
                 }
 
                 if(TextFrom_testTextfield)
@@ -3144,7 +3206,8 @@ void callback::submenu1(int Param)
                     SubMenu->delText(TextFrom_testTextfield);
                     TextFrom_testTextfield = nullptr;
                 }
-                TextFrom_testTextfield = SubMenu->addText("Der Text im Textfeld lautet: " + testTextfield->getText(), Point16(200, 400), FontSize::Large);
+                TextFrom_testTextfield = SubMenu->addText("Der Text im Textfeld lautet: " + testTextfield->getText(),
+                                                          Point16(200, 400), FontSize::Large);
             }
             counter++;
             break;

--- a/callbacks.cpp
+++ b/callbacks.cpp
@@ -46,7 +46,7 @@ void callback::PleaseWait(int Param)
             // we don't register this window cause we will destroy it manually if we need
             // global::s2->RegisterCallback(PleaseWait);
 
-            WNDWait->addText("Please wait ...", Point16(10, 10), FontSize::Large);
+            WNDWait->addText("Please wait ...", Position(10, 10), FontSize::Large);
             // we need to render this window NOW, cause the render loop will do it too late (when the operation
             // is done and we don't need the "Please wait"-window anymore)
             CSurface::Draw(global::s2->getDisplaySurface(), WNDWait->getSurface(),
@@ -99,7 +99,7 @@ void callback::ShowStatus(int Param)
             WND = global::s2->RegisterWindow(std::make_unique<CWindow>(ShowStatus, WINDOWQUIT, WindowPos::Center,
                                                                        Extent(250, 90), "Status", WINDOW_GREEN1,
                                                                        WINDOW_CLOSE | WINDOW_MINIMIZE | WINDOW_MOVE));
-            txt = WND->addText("", Point16(26, 20), FontSize::Large, FontColor::Yellow);
+            txt = WND->addText("", Position(26, 20), FontSize::Large, FontColor::Yellow);
             break;
         case SHOW_SUCCESS:
             assert(txt);
@@ -140,14 +140,13 @@ void callback::mainmenu(int Param)
     {
         case INITIALIZING_CALL:
             MainMenu = global::s2->RegisterMenu(std::make_unique<CMenu>(SPLASHSCREEN_MAINMENU));
-            MainMenu->addButton(mainmenu, ENDGAME, Point16(50, 400), Extent16(200, 20), BUTTON_RED1, "Quit program");
+            MainMenu->addButton(mainmenu, ENDGAME, Position(50, 400), Extent(200, 20), BUTTON_RED1, "Quit program");
 #ifdef _ADMINMODE
-            MainMenu->addButton(submenu1, INITIALIZING_CALL, Point16(50, 200), Extent16(200, 20), BUTTON_GREY,
+            MainMenu->addButton(submenu1, INITIALIZING_CALL, Position(50, 200), Extent(200, 20), BUTTON_GREY,
                                 "Submenu_1");
 #endif
-            MainMenu->addButton(mainmenu, STARTEDITOR, Point16(50, 160), Extent16(200, 20), BUTTON_RED1,
-                                "Start editor");
-            MainMenu->addButton(mainmenu, OPTIONS, Point16(50, 370), Extent16(200, 20), BUTTON_GREEN2, "Options");
+            MainMenu->addButton(mainmenu, STARTEDITOR, Position(50, 160), Extent(200, 20), BUTTON_RED1, "Start editor");
+            MainMenu->addButton(mainmenu, OPTIONS, Position(50, 370), Extent(200, 20), BUTTON_GREEN2, "Options");
             break;
 
         case CALL_FROM_GAMELOOP: break;
@@ -239,23 +238,23 @@ void callback::submenuOptions(int Param)
         case INITIALIZING_CALL:
             SubMenu = global::s2->RegisterMenu(std::make_unique<CMenu>(SPLASHSCREEN_SUBMENU3));
             // add button for "back to main menu"
-            SubMenu->addButton(submenuOptions, MAINMENU, Point16(global::s2->GameResolution.x / 2 - 100, 440),
-                               Extent16(200, 20), BUTTON_RED1, "back");
+            SubMenu->addButton(submenuOptions, MAINMENU, Position(global::s2->GameResolution.x / 2 - 100, 440),
+                               Extent(200, 20), BUTTON_RED1, "back");
             // add menu title
-            SubMenu->addText("Options", Point16(global::s2->GameResolution.x / 2 - 20, 10), FontSize::Large);
+            SubMenu->addText("Options", Position(global::s2->GameResolution.x / 2 - 20, 10), FontSize::Large);
             // add screen resolution
             if(TextResolution)
                 SubMenu->delText(TextResolution);
             TextResolution = SubMenu->addText(
               helpers::format("Game Resolution: %d*%d / %s", global::s2->GameResolution.x, global::s2->GameResolution.y,
                               (global::s2->fullscreen ? "Fullscreen" : "Window")),
-              Point16(global::s2->GameResolution.x / 2 - 110, 50), FontSize::Medium);
+              Position(global::s2->GameResolution.x / 2 - 110, 50), FontSize::Medium);
             if(ButtonFullscreen)
                 SubMenu->delButton(ButtonFullscreen);
             ButtonFullscreen =
-              SubMenu->addButton(submenuOptions, FULLSCREEN, Point16(global::s2->GameResolution.x / 2 - 100, 190),
-                                 Extent16(200, 20), BUTTON_RED1, (global::s2->fullscreen ? "WINDOW" : "FULLSCREEN"));
-            SelectBoxRes = SubMenu->addSelectBox(ButtonFullscreen->getPos() - Point16(0, 120), Extent16(200, 110),
+              SubMenu->addButton(submenuOptions, FULLSCREEN, Position(global::s2->GameResolution.x / 2 - 100, 190),
+                                 Extent(200, 20), BUTTON_RED1, (global::s2->fullscreen ? "WINDOW" : "FULLSCREEN"));
+            SelectBoxRes = SubMenu->addSelectBox(ButtonFullscreen->getPos() - Position(0, 120), Extent(200, 110),
                                                  FontSize::Medium, FontColor::Yellow, BUTTON_GREY);
             SelectBoxRes->addOption("800 x 600 (SVGA)", submenuOptions, SELECTBOX_800_600);
             SelectBoxRes->addOption("832 x 624 (Half Megapixel)", submenuOptions, SELECTBOX_832_624);
@@ -604,9 +603,8 @@ void callback::EditorHelpMenu(int Param)
               std::make_unique<CWindow>(EditorHelpMenu, WINDOWQUIT, WindowPos::Center, Extent(640, 380), "Hilfe",
                                         WINDOW_GREEN2, WINDOW_CLOSE | WINDOW_MOVE | WINDOW_RESIZE | WINDOW_MINIMIZE));
 
-            SelectBoxHelp =
-              WNDHelp->addSelectBox(Point16(0, 0), Extent16(WNDHelp->getSize() - WNDHelp->getBorderSize()),
-                                    FontSize::Medium, FontColor::Yellow, BUTTON_GREEN1);
+            SelectBoxHelp = WNDHelp->addSelectBox(Position(0, 0), Extent(WNDHelp->getSize() - WNDHelp->getBorderSize()),
+                                                  FontSize::Medium, FontColor::Yellow, BUTTON_GREEN1);
             SelectBoxHelp->addOption("User map path: " + global::userMapsPath.string());
             SelectBoxHelp->addOption("");
             SelectBoxHelp->addOption("Help-Menu........................................................................"
@@ -714,10 +712,10 @@ void callback::EditorMainMenu(int Param)
             WNDMain = global::s2->RegisterWindow(std::make_unique<CWindow>(EditorMainMenu, WINDOWQUIT,
                                                                            WindowPos::Center, Extent(220, 320),
                                                                            "Main menu", WINDOW_GREEN1, WINDOW_CLOSE));
-            WNDMain->addButton(EditorMainMenu, LOADMENU, Point16(8, 100), Extent16(190, 20), BUTTON_GREEN2, "Load map");
-            WNDMain->addButton(EditorMainMenu, SAVEMENU, Point16(8, 125), Extent16(190, 20), BUTTON_GREEN2, "Save map");
+            WNDMain->addButton(EditorMainMenu, LOADMENU, Position(8, 100), Extent(190, 20), BUTTON_GREEN2, "Load map");
+            WNDMain->addButton(EditorMainMenu, SAVEMENU, Position(8, 125), Extent(190, 20), BUTTON_GREEN2, "Save map");
 
-            WNDMain->addButton(EditorMainMenu, QUITMENU, Point16(8, 260), Extent16(190, 20), BUTTON_GREEN2,
+            WNDMain->addButton(EditorMainMenu, QUITMENU, Position(8, 260), Extent(190, 20), BUTTON_GREEN2,
                                "Leave editor");
             break;
 
@@ -762,7 +760,7 @@ void callback::EditorLoadMenu(int Param)
               EditorLoadMenu, WINDOWQUIT, WindowPos::Center, Extent(280, 320), "Load", WINDOW_GREEN1, WINDOW_CLOSE));
             MapObj = global::s2->getMapObj();
 
-            auto* CB_Filename = WNDLoad->addSelectBox(Point16(10, 5), Extent16(160, 280), FontSize::Medium);
+            auto* CB_Filename = WNDLoad->addSelectBox(Position(10, 5), Extent(160, 280), FontSize::Medium);
             curFilename.clear();
             for(const auto& itFile : bfs::directory_iterator(global::userMapsPath))
             {
@@ -772,8 +770,8 @@ void callback::EditorLoadMenu(int Param)
                     CB_Filename->addOption(filename, [filename](int) { curFilename = filename; });
                 }
             }
-            WNDLoad->addButton(EditorLoadMenu, LOADMAP, Point16(175, 140), Extent16(90, 20), BUTTON_GREY, "Load");
-            WNDLoad->addButton(EditorLoadMenu, WINDOWQUIT, Point16(175, 165), Extent16(90, 20), BUTTON_RED1, "Abort");
+            WNDLoad->addButton(EditorLoadMenu, LOADMAP, Position(175, 140), Extent(90, 20), BUTTON_GREY, "Load");
+            WNDLoad->addButton(EditorLoadMenu, WINDOWQUIT, Position(175, 165), Extent(90, 20), BUTTON_RED1, "Abort");
             break;
         }
         case WINDOWQUIT:
@@ -857,18 +855,18 @@ void callback::EditorSaveMenu(int Param)
                                                                                "Save", WINDOW_GREEN1, WINDOW_CLOSE));
                 MapObj = global::s2->getMapObj();
 
-                WNDSave->addText("Filename", Point16(100, 2), FontSize::Small);
-                TXTF_Filename = WNDSave->addTextfield(Point16(10, 13), 21, 1);
+                WNDSave->addText("Filename", Position(100, 2), FontSize::Small);
+                TXTF_Filename = WNDSave->addTextfield(Position(10, 13), 21, 1);
                 const bfs::path filePath = MapObj->getFilepath().empty() ? "MyMap" : MapObj->getFilepath();
                 TXTF_Filename->setText(filePath.filename().string());
-                WNDSave->addText("Mapname", Point16(98, 38), FontSize::Small);
-                TXTF_Mapname = WNDSave->addTextfield(Point16(10, 50), 19, 1);
+                WNDSave->addText("Mapname", Position(98, 38), FontSize::Small);
+                TXTF_Mapname = WNDSave->addTextfield(Position(10, 50), 19, 1);
                 TXTF_Mapname->setText(MapObj->getMapname());
-                WNDSave->addText("Author", Point16(110, 75), FontSize::Medium);
-                TXTF_Author = WNDSave->addTextfield(Point16(10, 87), 19, 1);
+                WNDSave->addText("Author", Position(110, 75), FontSize::Medium);
+                TXTF_Author = WNDSave->addTextfield(Position(10, 87), 19, 1);
                 TXTF_Author->setText(MapObj->getAuthor());
-                WNDSave->addButton(EditorSaveMenu, SAVEMAP, Point16(170, 120), Extent16(90, 20), BUTTON_GREY, "Save");
-                WNDSave->addButton(EditorSaveMenu, WINDOWQUIT, Point16(170, 145), Extent16(90, 20), BUTTON_RED1,
+                WNDSave->addButton(EditorSaveMenu, SAVEMAP, Position(170, 120), Extent(90, 20), BUTTON_GREY, "Save");
+                WNDSave->addButton(EditorSaveMenu, WINDOWQUIT, Position(170, 145), Extent(90, 20), BUTTON_RED1,
                                    "Abort");
                 break;
             }
@@ -926,9 +924,9 @@ void callback::EditorQuitMenu(int Param)
                 break;
             WNDBackToMainMenu = global::s2->RegisterWindow(
               std::make_unique<CWindow>(EditorQuitMenu, WINDOWQUIT, WindowPos::Center, Extent(212, 110), "Exit?"));
-            WNDBackToMainMenu->addButton(EditorQuitMenu, BACKTOMAIN, Point16(0, 0), Extent16(100, 80), BUTTON_GREEN2,
+            WNDBackToMainMenu->addButton(EditorQuitMenu, BACKTOMAIN, Position(0, 0), Extent(100, 80), BUTTON_GREEN2,
                                          nullptr, PICTURE_SMALL_TICK);
-            WNDBackToMainMenu->addButton(EditorQuitMenu, NOTBACKTOMAIN, Point16(100, 0), Extent16(100, 80), BUTTON_RED1,
+            WNDBackToMainMenu->addButton(EditorQuitMenu, NOTBACKTOMAIN, Position(100, 0), Extent(100, 80), BUTTON_RED1,
                                          nullptr, PICTURE_SMALL_CROSS);
             break;
 
@@ -1024,24 +1022,24 @@ void callback::EditorTextureMenu(int Param)
             MapObj->setMode(EDITOR_MODE_TEXTURE);
             MapObj->setModeContent(TRIANGLE_TEXTURE_SNOW);
 
-            WNDTexture->addPicture(EditorTextureMenu, PICSNOW, Point16(2, 2), textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICSTEPPE, Point16(36, 2), textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICSWAMP, Point16(70, 2), textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICFLOWER, Point16(104, 2), textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICMINING1, Point16(138, 2), textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICMINING2, Point16(172, 2), textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICMINING3, Point16(2, 36), textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICMINING4, Point16(36, 36), textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICSTEPPE_MEADOW1, Point16(70, 36), textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICMEADOW1, Point16(104, 36), textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICMEADOW2, Point16(138, 36), textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICMEADOW3, Point16(172, 36), textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICSTEPPE_MEADOW2, Point16(2, 70), textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICMINING_MEADOW, Point16(36, 70), textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICWATER, Point16(70, 70), textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICLAVA, Point16(104, 70), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICSNOW, Position(2, 2), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICSTEPPE, Position(36, 2), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICSWAMP, Position(70, 2), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICFLOWER, Position(104, 2), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICMINING1, Position(138, 2), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICMINING2, Position(172, 2), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICMINING3, Position(2, 36), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICMINING4, Position(36, 36), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICSTEPPE_MEADOW1, Position(70, 36), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICMEADOW1, Position(104, 36), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICMEADOW2, Position(138, 36), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICMEADOW3, Position(172, 36), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICSTEPPE_MEADOW2, Position(2, 70), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICMINING_MEADOW, Position(36, 70), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICWATER, Position(70, 70), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICLAVA, Position(104, 70), textureIndex++);
             if(map->type != MAP_WASTELAND)
-                WNDTexture->addPicture(EditorTextureMenu, PICMEADOW_MIXED, Point16(138, 70), textureIndex);
+                WNDTexture->addPicture(EditorTextureMenu, PICMEADOW_MIXED, Position(138, 70), textureIndex);
             break;
 
         case PICSNOW: MapObj->setModeContent(TRIANGLE_TEXTURE_SNOW); break;
@@ -1148,30 +1146,30 @@ void callback::EditorTreeMenu(int Param)
             switch(map->type)
             {
                 case MAP_GREENLAND:
-                    WNDTree->addPicture(EditorTreeMenu, PICPINE, Point16(2, 2), PICTURE_TREE_PINE);
-                    WNDTree->addPicture(EditorTreeMenu, PICBIRCH, Point16(36, 2), PICTURE_TREE_BIRCH);
-                    WNDTree->addPicture(EditorTreeMenu, PICOAK, Point16(70, 2), PICTURE_TREE_OAK);
-                    WNDTree->addPicture(EditorTreeMenu, PICPALM1, Point16(104, 2), PICTURE_TREE_PALM1);
-                    WNDTree->addPicture(EditorTreeMenu, PICPALM2, Point16(2, 36), PICTURE_TREE_PALM2);
-                    WNDTree->addPicture(EditorTreeMenu, PICPINEAPPLE, Point16(36, 36), PICTURE_TREE_PINEAPPLE);
-                    WNDTree->addPicture(EditorTreeMenu, PICCYPRESS, Point16(70, 36), PICTURE_TREE_CYPRESS);
-                    WNDTree->addPicture(EditorTreeMenu, PICCHERRY, Point16(104, 36), PICTURE_TREE_CHERRY);
-                    WNDTree->addPicture(EditorTreeMenu, PICFIR, Point16(2, 72), PICTURE_TREE_FIR);
-                    WNDTree->addPicture(EditorTreeMenu, PICWOOD_MIXED, Point16(36, 70), PICTURE_TREE_WOOD_MIXED);
-                    WNDTree->addPicture(EditorTreeMenu, PICPALM_MIXED, Point16(70, 70), PICTURE_TREE_PALM_MIXED);
+                    WNDTree->addPicture(EditorTreeMenu, PICPINE, Position(2, 2), PICTURE_TREE_PINE);
+                    WNDTree->addPicture(EditorTreeMenu, PICBIRCH, Position(36, 2), PICTURE_TREE_BIRCH);
+                    WNDTree->addPicture(EditorTreeMenu, PICOAK, Position(70, 2), PICTURE_TREE_OAK);
+                    WNDTree->addPicture(EditorTreeMenu, PICPALM1, Position(104, 2), PICTURE_TREE_PALM1);
+                    WNDTree->addPicture(EditorTreeMenu, PICPALM2, Position(2, 36), PICTURE_TREE_PALM2);
+                    WNDTree->addPicture(EditorTreeMenu, PICPINEAPPLE, Position(36, 36), PICTURE_TREE_PINEAPPLE);
+                    WNDTree->addPicture(EditorTreeMenu, PICCYPRESS, Position(70, 36), PICTURE_TREE_CYPRESS);
+                    WNDTree->addPicture(EditorTreeMenu, PICCHERRY, Position(104, 36), PICTURE_TREE_CHERRY);
+                    WNDTree->addPicture(EditorTreeMenu, PICFIR, Position(2, 72), PICTURE_TREE_FIR);
+                    WNDTree->addPicture(EditorTreeMenu, PICWOOD_MIXED, Position(36, 70), PICTURE_TREE_WOOD_MIXED);
+                    WNDTree->addPicture(EditorTreeMenu, PICPALM_MIXED, Position(70, 70), PICTURE_TREE_PALM_MIXED);
                     break;
                 case MAP_WASTELAND:
-                    WNDTree->addPicture(EditorTreeMenu, PICFLAPHAT, Point16(2, 2), PICTURE_TREE_FLAPHAT);
-                    WNDTree->addPicture(EditorTreeMenu, PICSPIDER, Point16(36, 2), PICTURE_TREE_SPIDER);
-                    WNDTree->addPicture(EditorTreeMenu, PICPINEAPPLE, Point16(70, 2), PICTURE_TREE_PINEAPPLE);
-                    WNDTree->addPicture(EditorTreeMenu, PICCHERRY, Point16(104, 2), PICTURE_TREE_CHERRY);
+                    WNDTree->addPicture(EditorTreeMenu, PICFLAPHAT, Position(2, 2), PICTURE_TREE_FLAPHAT);
+                    WNDTree->addPicture(EditorTreeMenu, PICSPIDER, Position(36, 2), PICTURE_TREE_SPIDER);
+                    WNDTree->addPicture(EditorTreeMenu, PICPINEAPPLE, Position(70, 2), PICTURE_TREE_PINEAPPLE);
+                    WNDTree->addPicture(EditorTreeMenu, PICCHERRY, Position(104, 2), PICTURE_TREE_CHERRY);
                     break;
                 case MAP_WINTERLAND:
-                    WNDTree->addPicture(EditorTreeMenu, PICPINE, Point16(2, 2), PICTURE_TREE_PINE);
-                    WNDTree->addPicture(EditorTreeMenu, PICBIRCH, Point16(36, 2), PICTURE_TREE_BIRCH);
-                    WNDTree->addPicture(EditorTreeMenu, PICCYPRESS, Point16(70, 2), PICTURE_TREE_CYPRESS);
-                    WNDTree->addPicture(EditorTreeMenu, PICFIR, Point16(104, 2), PICTURE_TREE_FIR);
-                    WNDTree->addPicture(EditorTreeMenu, PICWOOD_MIXED, Point16(2, 36), PICTURE_TREE_WOOD_MIXED);
+                    WNDTree->addPicture(EditorTreeMenu, PICPINE, Position(2, 2), PICTURE_TREE_PINE);
+                    WNDTree->addPicture(EditorTreeMenu, PICBIRCH, Position(36, 2), PICTURE_TREE_BIRCH);
+                    WNDTree->addPicture(EditorTreeMenu, PICCYPRESS, Position(70, 2), PICTURE_TREE_CYPRESS);
+                    WNDTree->addPicture(EditorTreeMenu, PICFIR, Position(104, 2), PICTURE_TREE_FIR);
+                    WNDTree->addPicture(EditorTreeMenu, PICWOOD_MIXED, Position(2, 36), PICTURE_TREE_WOOD_MIXED);
                     break;
                 default: // should not happen
                     break;
@@ -1334,10 +1332,10 @@ void callback::EditorResourceMenu(int Param)
                                         WINDOW_GREEN1, WINDOW_CLOSE | WINDOW_MINIMIZE | WINDOW_MOVE));
             MapObj = global::s2->getMapObj();
 
-            WNDResource->addPicture(EditorResourceMenu, PICGOLD, Point16(2, 2), PICTURE_RESOURCE_GOLD);
-            WNDResource->addPicture(EditorResourceMenu, PICORE, Point16(36, 2), PICTURE_RESOURCE_ORE);
-            WNDResource->addPicture(EditorResourceMenu, PICCOAL, Point16(70, 2), PICTURE_RESOURCE_COAL);
-            WNDResource->addPicture(EditorResourceMenu, PICGRANITE, Point16(104, 2), PICTURE_RESOURCE_GRANITE);
+            WNDResource->addPicture(EditorResourceMenu, PICGOLD, Position(2, 2), PICTURE_RESOURCE_GOLD);
+            WNDResource->addPicture(EditorResourceMenu, PICORE, Position(36, 2), PICTURE_RESOURCE_ORE);
+            WNDResource->addPicture(EditorResourceMenu, PICCOAL, Position(70, 2), PICTURE_RESOURCE_COAL);
+            WNDResource->addPicture(EditorResourceMenu, PICGRANITE, Position(104, 2), PICTURE_RESOURCE_GRANITE);
 
             MapObj->setMode(EDITOR_MODE_RESOURCE_RAISE);
             MapObj->setModeContent(0x51);
@@ -1439,48 +1437,52 @@ void callback::EditorLandscapeMenu(int Param)
             switch(map->type)
             {
                 case MAP_GREENLAND:
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICGRANITE, Point16(2, 2), PICTURE_LANDSCAPE_GRANITE);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICTREEDEAD, Point16(36, 2),
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICGRANITE, Position(2, 2),
+                                             PICTURE_LANDSCAPE_GRANITE);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICTREEDEAD, Position(36, 2),
                                              PICTURE_LANDSCAPE_TREE_DEAD);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSTONE, Point16(70, 2), PICTURE_LANDSCAPE_STONE);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICCACTUS, Point16(2, 36), PICTURE_LANDSCAPE_CACTUS);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICPEBBLE, Point16(36, 36), PICTURE_LANDSCAPE_PEBBLE);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICBUSH, Point16(70, 36), PICTURE_LANDSCAPE_BUSH);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSHRUB, Point16(2, 70), PICTURE_LANDSCAPE_SHRUB);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICBONE, Point16(36, 70), PICTURE_LANDSCAPE_BONE);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICMUSHROOM, Point16(70, 70),
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSTONE, Position(70, 2), PICTURE_LANDSCAPE_STONE);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICCACTUS, Position(2, 36), PICTURE_LANDSCAPE_CACTUS);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICPEBBLE, Position(36, 36),
+                                             PICTURE_LANDSCAPE_PEBBLE);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICBUSH, Position(70, 36), PICTURE_LANDSCAPE_BUSH);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSHRUB, Position(2, 70), PICTURE_LANDSCAPE_SHRUB);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICBONE, Position(36, 70), PICTURE_LANDSCAPE_BONE);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICMUSHROOM, Position(70, 70),
                                              PICTURE_LANDSCAPE_MUSHROOM);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICFLOWERS, Point16(5, 107), MAPPIC_FLOWERS);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICFLOWERS, Position(5, 107), MAPPIC_FLOWERS);
                     break;
                 case MAP_WASTELAND:
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICGRANITE, Point16(2, 2), PICTURE_LANDSCAPE_GRANITE);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICTREEDEAD, Point16(36, 2),
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICGRANITE, Position(2, 2),
+                                             PICTURE_LANDSCAPE_GRANITE);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICTREEDEAD, Position(36, 2),
                                              PICTURE_LANDSCAPE_TREE_DEAD);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSTONE, Point16(70, 2), PICTURE_LANDSCAPE_STONE);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSTALAGMITE, Point16(2, 36),
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSTONE, Position(70, 2), PICTURE_LANDSCAPE_STONE);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSTALAGMITE, Position(2, 36),
                                              PICTURE_LANDSCAPE_STALAGMITE);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICPEBBLE, Point16(36, 36), PICTURE_LANDSCAPE_PEBBLE);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICBUSH, Point16(70, 36), PICTURE_LANDSCAPE_BUSH);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSHRUB, Point16(2, 70), PICTURE_LANDSCAPE_SHRUB);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICBONE, Point16(36, 70), PICTURE_LANDSCAPE_BONE);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICMUSHROOM, Point16(70, 70),
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICPEBBLE, Position(36, 36),
+                                             PICTURE_LANDSCAPE_PEBBLE);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICBUSH, Position(70, 36), PICTURE_LANDSCAPE_BUSH);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSHRUB, Position(2, 70), PICTURE_LANDSCAPE_SHRUB);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICBONE, Position(36, 70), PICTURE_LANDSCAPE_BONE);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICMUSHROOM, Position(70, 70),
                                              PICTURE_LANDSCAPE_MUSHROOM);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICFLOWERS, Point16(5, 107), MAPPIC_FLOWERS);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICFLOWERS, Position(5, 107), MAPPIC_FLOWERS);
                     break;
                 case MAP_WINTERLAND:
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICGRANITE, Point16(2, 2),
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICGRANITE, Position(2, 2),
                                              PICTURE_LANDSCAPE_GRANITE_WINTER);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICTREEDEAD, Point16(36, 2),
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICTREEDEAD, Position(36, 2),
                                              PICTURE_LANDSCAPE_TREE_DEAD_WINTER);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSTONE, Point16(70, 2),
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSTONE, Position(70, 2),
                                              PICTURE_LANDSCAPE_STONE_WINTER);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICPEBBLE, Point16(2, 36),
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICPEBBLE, Position(2, 36),
                                              PICTURE_LANDSCAPE_PEBBLE_WINTER);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICBONE, Point16(36, 36),
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICBONE, Position(36, 36),
                                              PICTURE_LANDSCAPE_BONE_WINTER);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICMUSHROOM, Point16(70, 36),
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICMUSHROOM, Position(70, 36),
                                              PICTURE_LANDSCAPE_MUSHROOM_WINTER);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICFLOWERS, Point16(73, 73), MAPPIC_FLOWERS);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICFLOWERS, Position(73, 73), MAPPIC_FLOWERS);
                     break;
                 default: // should not happen
                     break;
@@ -1631,12 +1633,12 @@ void callback::EditorAnimalMenu(int Param)
             WNDAnimal = global::s2->RegisterWindow(
               std::make_unique<CWindow>(EditorAnimalMenu, WINDOWQUIT, Pos, Extent(116, 106), "Animals", WINDOW_GREEN1,
                                         WINDOW_CLOSE | WINDOW_MINIMIZE | WINDOW_MOVE));
-            WNDAnimal->addPicture(EditorAnimalMenu, PICRABBIT, Point16(2, 2), PICTURE_ANIMAL_RABBIT);
-            WNDAnimal->addPicture(EditorAnimalMenu, PICFOX, Point16(36, 2), PICTURE_ANIMAL_FOX);
-            WNDAnimal->addPicture(EditorAnimalMenu, PICSTAG, Point16(70, 2), PICTURE_ANIMAL_STAG);
-            WNDAnimal->addPicture(EditorAnimalMenu, PICROE, Point16(2, 36), PICTURE_ANIMAL_ROE);
-            WNDAnimal->addPicture(EditorAnimalMenu, PICDUCK, Point16(36, 36), PICTURE_ANIMAL_DUCK);
-            WNDAnimal->addPicture(EditorAnimalMenu, PICSHEEP, Point16(70, 36), PICTURE_ANIMAL_SHEEP);
+            WNDAnimal->addPicture(EditorAnimalMenu, PICRABBIT, Position(2, 2), PICTURE_ANIMAL_RABBIT);
+            WNDAnimal->addPicture(EditorAnimalMenu, PICFOX, Position(36, 2), PICTURE_ANIMAL_FOX);
+            WNDAnimal->addPicture(EditorAnimalMenu, PICSTAG, Position(70, 2), PICTURE_ANIMAL_STAG);
+            WNDAnimal->addPicture(EditorAnimalMenu, PICROE, Position(2, 36), PICTURE_ANIMAL_ROE);
+            WNDAnimal->addPicture(EditorAnimalMenu, PICDUCK, Position(36, 36), PICTURE_ANIMAL_DUCK);
+            WNDAnimal->addPicture(EditorAnimalMenu, PICSHEEP, Position(70, 36), PICTURE_ANIMAL_SHEEP);
 
             MapObj = global::s2->getMapObj();
             MapObj->setMode(EDITOR_MODE_ANIMAL);
@@ -1744,11 +1746,11 @@ void callback::EditorPlayerMenu(int Param)
             MapObj->setMode(EDITOR_MODE_FLAG);
             MapObj->setModeContent(PlayerIdx);
 
-            WNDPlayer->addButton(EditorPlayerMenu, PLAYER_REDUCE, Point16(0, 0), Extent16(20, 20), BUTTON_GREY, "-");
+            WNDPlayer->addButton(EditorPlayerMenu, PLAYER_REDUCE, Position(0, 0), Extent(20, 20), BUTTON_GREY, "-");
             PlayerNumberText =
-              WNDPlayer->addText(std::to_string(PlayerIdx + 1), Point16(26, 4), FontSize::Large, FontColor::Orange);
-            WNDPlayer->addButton(EditorPlayerMenu, PLAYER_RAISE, Point16(40, 0), Extent16(20, 20), BUTTON_GREY, "+");
-            WNDPlayer->addButton(EditorPlayerMenu, GOTO_PLAYER, Point16(0, 20), Extent16(60, 20), BUTTON_GREY, "Go to");
+              WNDPlayer->addText(std::to_string(PlayerIdx + 1), Position(26, 4), FontSize::Large, FontColor::Orange);
+            WNDPlayer->addButton(EditorPlayerMenu, PLAYER_RAISE, Position(40, 0), Extent(20, 20), BUTTON_GREY, "+");
+            WNDPlayer->addButton(EditorPlayerMenu, GOTO_PLAYER, Position(0, 20), Extent(60, 20), BUTTON_GREY, "Go to");
             break;
 
         case PLAYER_REDUCE:
@@ -1757,8 +1759,8 @@ void callback::EditorPlayerMenu(int Param)
                 PlayerIdx--;
                 MapObj->setModeContent(PlayerIdx);
                 WNDPlayer->delText(PlayerNumberText);
-                PlayerNumberText =
-                  WNDPlayer->addText(std::to_string(PlayerIdx + 1), Point16(26, 4), FontSize::Large, FontColor::Orange);
+                PlayerNumberText = WNDPlayer->addText(std::to_string(PlayerIdx + 1), Position(26, 4), FontSize::Large,
+                                                      FontColor::Orange);
             }
             break;
 
@@ -1768,8 +1770,8 @@ void callback::EditorPlayerMenu(int Param)
                 PlayerIdx++;
                 MapObj->setModeContent(PlayerIdx);
                 WNDPlayer->delText(PlayerNumberText);
-                PlayerNumberText =
-                  WNDPlayer->addText(std::to_string(PlayerIdx + 1), Point16(26, 4), FontSize::Large, FontColor::Orange);
+                PlayerNumberText = WNDPlayer->addText(std::to_string(PlayerIdx + 1), Position(26, 4), FontSize::Large,
+                                                      FontColor::Orange);
             }
             break;
 
@@ -1860,13 +1862,13 @@ void callback::EditorCursorMenu(int Param)
                                         WINDOW_CLOSE | WINDOW_MINIMIZE | WINDOW_MOVE));
             MapObj = global::s2->getMapObj();
 
-            CursorModeButton = WNDCursor->addButton(EditorCursorMenu, CURSORMODE, Point16(2, 2), Extent16(96, 32),
+            CursorModeButton = WNDCursor->addButton(EditorCursorMenu, CURSORMODE, Position(2, 2), Extent(96, 32),
                                                     BUTTON_GREY, "Hexagon");
-            CursorRandomButton = WNDCursor->addButton(EditorCursorMenu, CURSORRANDOM, Point16(2, 34), Extent16(196, 32),
+            CursorRandomButton = WNDCursor->addButton(EditorCursorMenu, CURSORRANDOM, Position(2, 34), Extent(196, 32),
                                                       BUTTON_GREY, "Cursor-Activity: static");
-            WNDCursor->addButton(EditorCursorMenu, TRIANGLE, Point16(2, 66), Extent16(32, 32), BUTTON_GREY, nullptr);
-            trianglePictureArrowUp = WNDCursor->addStaticPicture(Point16(8, 74), CURSOR_SYMBOL_ARROW_UP);
-            trianglePictureArrowDown = WNDCursor->addStaticPicture(Point16(17, 77), CURSOR_SYMBOL_ARROW_DOWN);
+            WNDCursor->addButton(EditorCursorMenu, TRIANGLE, Position(2, 66), Extent(32, 32), BUTTON_GREY, nullptr);
+            trianglePictureArrowUp = WNDCursor->addStaticPicture(Position(8, 74), CURSOR_SYMBOL_ARROW_UP);
+            trianglePictureArrowDown = WNDCursor->addStaticPicture(Position(17, 77), CURSOR_SYMBOL_ARROW_DOWN);
             if(MapObj)
             {
                 MapObj->setVertexFillRSU(true);
@@ -1890,7 +1892,7 @@ void callback::EditorCursorMenu(int Param)
                 // add random if necessary
                 if(trianglePictureRandom == -1)
                     trianglePictureRandom =
-                      WNDCursor->addStaticPicture(Point16(14, 76), FONT14_SPACE + 31 * 7 + 5); // Interrogation point
+                      WNDCursor->addStaticPicture(Position(14, 76), FONT14_SPACE + 31 * 7 + 5); // Interrogation point
                 MapObj->setVertexFillRSU(false);
                 MapObj->setVertexFillUSD(false);
                 MapObj->setVertexFillRandom(true);
@@ -1898,10 +1900,10 @@ void callback::EditorCursorMenu(int Param)
             {
                 // only arrow down is shown, so upgrade to both arrows
                 // add arrow up
-                trianglePictureArrowUp = WNDCursor->addStaticPicture(Point16(8, 74), CURSOR_SYMBOL_ARROW_UP);
+                trianglePictureArrowUp = WNDCursor->addStaticPicture(Position(8, 74), CURSOR_SYMBOL_ARROW_UP);
                 // add arrow down if necessary
                 if(trianglePictureArrowDown == -1)
-                    trianglePictureArrowDown = WNDCursor->addStaticPicture(Point16(17, 77), CURSOR_SYMBOL_ARROW_DOWN);
+                    trianglePictureArrowDown = WNDCursor->addStaticPicture(Position(17, 77), CURSOR_SYMBOL_ARROW_DOWN);
                 MapObj->setVertexFillRSU(true);
                 MapObj->setVertexFillUSD(true);
                 MapObj->setVertexFillRandom(false);
@@ -1914,7 +1916,7 @@ void callback::EditorCursorMenu(int Param)
                     WNDCursor->delStaticPicture(trianglePictureArrowUp);
                     trianglePictureArrowUp = -1;
                 }
-                trianglePictureArrowDown = WNDCursor->addStaticPicture(Point16(17, 77), CURSOR_SYMBOL_ARROW_DOWN);
+                trianglePictureArrowDown = WNDCursor->addStaticPicture(Position(17, 77), CURSOR_SYMBOL_ARROW_DOWN);
                 MapObj->setVertexFillRSU(false);
                 MapObj->setVertexFillUSD(true);
                 MapObj->setVertexFillRandom(false);
@@ -1925,7 +1927,7 @@ void callback::EditorCursorMenu(int Param)
                 trianglePictureRandom = -1;
                 // add arrow up if necessary
                 if(trianglePictureArrowUp == -1)
-                    trianglePictureArrowUp = WNDCursor->addStaticPicture(Point16(8, 74), CURSOR_SYMBOL_ARROW_UP);
+                    trianglePictureArrowUp = WNDCursor->addStaticPicture(Position(8, 74), CURSOR_SYMBOL_ARROW_UP);
                 // delete arrow down if necessary
                 if(trianglePictureArrowDown != -1)
                 {
@@ -1946,12 +1948,12 @@ void callback::EditorCursorMenu(int Param)
             }
             if(MapObj->getHexagonMode())
             {
-                CursorModeButton = WNDCursor->addButton(EditorCursorMenu, CURSORMODE, Point16(2, 2), Extent16(96, 32),
+                CursorModeButton = WNDCursor->addButton(EditorCursorMenu, CURSORMODE, Position(2, 2), Extent(96, 32),
                                                         BUTTON_GREY, "Square");
                 MapObj->setHexagonMode(false);
             } else
             {
-                CursorModeButton = WNDCursor->addButton(EditorCursorMenu, CURSORMODE, Point16(2, 2), Extent16(96, 32),
+                CursorModeButton = WNDCursor->addButton(EditorCursorMenu, CURSORMODE, Position(2, 2), Extent(96, 32),
                                                         BUTTON_GREY, "Hexagon");
                 MapObj->setHexagonMode(true);
             }
@@ -1964,13 +1966,13 @@ void callback::EditorCursorMenu(int Param)
             }
             if(MapObj->getVertexActivityRandom())
             {
-                CursorRandomButton = WNDCursor->addButton(EditorCursorMenu, CURSORRANDOM, Point16(2, 34),
-                                                          Extent16(196, 32), BUTTON_GREY, "Cursor-Activity: static");
+                CursorRandomButton = WNDCursor->addButton(EditorCursorMenu, CURSORRANDOM, Position(2, 34),
+                                                          Extent(196, 32), BUTTON_GREY, "Cursor-Activity: static");
                 MapObj->setVertexActivityRandom(false);
             } else
             {
-                CursorRandomButton = WNDCursor->addButton(EditorCursorMenu, CURSORRANDOM, Point16(2, 34),
-                                                          Extent16(196, 32), BUTTON_GREY, "Cursor-Activity: random");
+                CursorRandomButton = WNDCursor->addButton(EditorCursorMenu, CURSORRANDOM, Position(2, 34),
+                                                          Extent(196, 32), BUTTON_GREY, "Cursor-Activity: random");
                 MapObj->setVertexActivityRandom(true);
             }
             break;
@@ -2060,62 +2062,63 @@ void callback::EditorCreateMenu(int Param)
                                         WINDOW_GREEN1, WINDOW_CLOSE | WINDOW_MOVE | WINDOW_MINIMIZE));
             MapObj = global::s2->getMapObj();
 
-            WNDCreate->addText("Width", Point16(95, 4), FontSize::Small, FontColor::Yellow);
-            WNDCreate->addButton(EditorCreateMenu, REDUCE_WIDTH_128, Point16(0, 15), Extent16(35, 20), BUTTON_GREY,
+            WNDCreate->addText("Width", Position(95, 4), FontSize::Small, FontColor::Yellow);
+            WNDCreate->addButton(EditorCreateMenu, REDUCE_WIDTH_128, Position(0, 15), Extent(35, 20), BUTTON_GREY,
                                  "128<-");
-            WNDCreate->addButton(EditorCreateMenu, REDUCE_WIDTH_16, Point16(35, 15), Extent16(35, 20), BUTTON_GREY,
+            WNDCreate->addButton(EditorCreateMenu, REDUCE_WIDTH_16, Position(35, 15), Extent(35, 20), BUTTON_GREY,
                                  "16<-");
-            WNDCreate->addButton(EditorCreateMenu, REDUCE_WIDTH_2, Point16(70, 15), Extent16(25, 20), BUTTON_GREY,
+            WNDCreate->addButton(EditorCreateMenu, REDUCE_WIDTH_2, Position(70, 15), Extent(25, 20), BUTTON_GREY,
                                  "2<-");
-            TextWidth = WNDCreate->addText(std::to_string(width), Point16(105, 17), FontSize::Large, FontColor::Yellow);
-            WNDCreate->addButton(EditorCreateMenu, RAISE_WIDTH_2, Point16(143, 15), Extent16(25, 20), BUTTON_GREY,
+            TextWidth =
+              WNDCreate->addText(std::to_string(width), Position(105, 17), FontSize::Large, FontColor::Yellow);
+            WNDCreate->addButton(EditorCreateMenu, RAISE_WIDTH_2, Position(143, 15), Extent(25, 20), BUTTON_GREY,
                                  "->2");
-            WNDCreate->addButton(EditorCreateMenu, RAISE_WIDTH_16, Point16(168, 15), Extent16(35, 20), BUTTON_GREY,
+            WNDCreate->addButton(EditorCreateMenu, RAISE_WIDTH_16, Position(168, 15), Extent(35, 20), BUTTON_GREY,
                                  "->16");
-            WNDCreate->addButton(EditorCreateMenu, RAISE_WIDTH_128, Point16(203, 15), Extent16(35, 20), BUTTON_GREY,
+            WNDCreate->addButton(EditorCreateMenu, RAISE_WIDTH_128, Position(203, 15), Extent(35, 20), BUTTON_GREY,
                                  "->128");
 
-            WNDCreate->addText("Height", Point16(100, 40), FontSize::Small, FontColor::Yellow);
-            WNDCreate->addButton(EditorCreateMenu, REDUCE_HEIGHT_128, Point16(0, 49), Extent16(35, 20), BUTTON_GREY,
+            WNDCreate->addText("Height", Position(100, 40), FontSize::Small, FontColor::Yellow);
+            WNDCreate->addButton(EditorCreateMenu, REDUCE_HEIGHT_128, Position(0, 49), Extent(35, 20), BUTTON_GREY,
                                  "128<-");
-            WNDCreate->addButton(EditorCreateMenu, REDUCE_HEIGHT_16, Point16(35, 49), Extent16(35, 20), BUTTON_GREY,
+            WNDCreate->addButton(EditorCreateMenu, REDUCE_HEIGHT_16, Position(35, 49), Extent(35, 20), BUTTON_GREY,
                                  "16<-");
-            WNDCreate->addButton(EditorCreateMenu, REDUCE_HEIGHT_2, Point16(70, 49), Extent16(25, 20), BUTTON_GREY,
+            WNDCreate->addButton(EditorCreateMenu, REDUCE_HEIGHT_2, Position(70, 49), Extent(25, 20), BUTTON_GREY,
                                  "2<-");
             TextHeight =
-              WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
-            WNDCreate->addButton(EditorCreateMenu, RAISE_HEIGHT_2, Point16(143, 49), Extent16(25, 20), BUTTON_GREY,
+              WNDCreate->addText(std::to_string(height), Position(105, 51), FontSize::Large, FontColor::Yellow);
+            WNDCreate->addButton(EditorCreateMenu, RAISE_HEIGHT_2, Position(143, 49), Extent(25, 20), BUTTON_GREY,
                                  "->2");
-            WNDCreate->addButton(EditorCreateMenu, RAISE_HEIGHT_16, Point16(168, 49), Extent16(35, 20), BUTTON_GREY,
+            WNDCreate->addButton(EditorCreateMenu, RAISE_HEIGHT_16, Position(168, 49), Extent(35, 20), BUTTON_GREY,
                                  "->16");
-            WNDCreate->addButton(EditorCreateMenu, RAISE_HEIGHT_128, Point16(203, 49), Extent16(35, 20), BUTTON_GREY,
+            WNDCreate->addButton(EditorCreateMenu, RAISE_HEIGHT_128, Position(203, 49), Extent(35, 20), BUTTON_GREY,
                                  "->128");
 
-            WNDCreate->addText("Landscape", Point16(85, 80), FontSize::Small, FontColor::Yellow);
+            WNDCreate->addText("Landscape", Position(85, 80), FontSize::Small, FontColor::Yellow);
             ButtonLandscape = WNDCreate->addButton(
-              EditorCreateMenu, CHANGE_LANDSCAPE, Point16(64, 93), Extent16(110, 20), BUTTON_GREY,
+              EditorCreateMenu, CHANGE_LANDSCAPE, Position(64, 93), Extent(110, 20), BUTTON_GREY,
               (LandscapeType == 0 ? "Greenland" : (LandscapeType == 1 ? "Wasteland" : "Winterworld")));
 
-            WNDCreate->addText("Main area", Point16(82, 120), FontSize::Small, FontColor::Yellow);
-            WNDCreate->addButton(EditorCreateMenu, TEXTURE_PREVIOUS, Point16(45, 139), Extent16(35, 20), BUTTON_GREY,
+            WNDCreate->addText("Main area", Position(82, 120), FontSize::Small, FontColor::Yellow);
+            WNDCreate->addButton(EditorCreateMenu, TEXTURE_PREVIOUS, Position(45, 139), Extent(35, 20), BUTTON_GREY,
                                  "-");
-            PicTextureIndex = WNDCreate->addStaticPicture(Point16(102, 133), PicTextureIndexGlobal);
-            WNDCreate->addButton(EditorCreateMenu, TEXTURE_NEXT, Point16(158, 139), Extent16(35, 20), BUTTON_GREY, "+");
+            PicTextureIndex = WNDCreate->addStaticPicture(Position(102, 133), PicTextureIndexGlobal);
+            WNDCreate->addButton(EditorCreateMenu, TEXTURE_NEXT, Position(158, 139), Extent(35, 20), BUTTON_GREY, "+");
 
-            WNDCreate->addText("Border size", Point16(103, 175), FontSize::Small, FontColor::Yellow);
-            WNDCreate->addButton(EditorCreateMenu, REDUCE_BORDER, Point16(45, 186), Extent16(35, 20), BUTTON_GREY, "-");
+            WNDCreate->addText("Border size", Position(103, 175), FontSize::Small, FontColor::Yellow);
+            WNDCreate->addButton(EditorCreateMenu, REDUCE_BORDER, Position(45, 186), Extent(35, 20), BUTTON_GREY, "-");
             TextBorder =
-              WNDCreate->addText(std::to_string(border), Point16(112, 188), FontSize::Large, FontColor::Yellow);
-            WNDCreate->addButton(EditorCreateMenu, RAISE_BORDER, Point16(158, 186), Extent16(35, 20), BUTTON_GREY, "+");
+              WNDCreate->addText(std::to_string(border), Position(112, 188), FontSize::Large, FontColor::Yellow);
+            WNDCreate->addButton(EditorCreateMenu, RAISE_BORDER, Position(158, 186), Extent(35, 20), BUTTON_GREY, "+");
 
-            WNDCreate->addText("Border area", Point16(65, 215), FontSize::Small, FontColor::Yellow);
-            WNDCreate->addButton(EditorCreateMenu, BORDER_TEXTURE_PREVIOUS, Point16(45, 234), Extent16(35, 20),
+            WNDCreate->addText("Border area", Position(65, 215), FontSize::Small, FontColor::Yellow);
+            WNDCreate->addButton(EditorCreateMenu, BORDER_TEXTURE_PREVIOUS, Position(45, 234), Extent(35, 20),
                                  BUTTON_GREY, "-");
-            PicBorderTextureIndex = WNDCreate->addStaticPicture(Point16(102, 228), PicBorderTextureIndexGlobal);
-            WNDCreate->addButton(EditorCreateMenu, BORDER_TEXTURE_NEXT, Point16(158, 234), Extent16(35, 20),
-                                 BUTTON_GREY, "+");
+            PicBorderTextureIndex = WNDCreate->addStaticPicture(Position(102, 228), PicBorderTextureIndexGlobal);
+            WNDCreate->addButton(EditorCreateMenu, BORDER_TEXTURE_NEXT, Position(158, 234), Extent(35, 20), BUTTON_GREY,
+                                 "+");
 
-            WNDCreate->addButton(EditorCreateMenu, CREATE_WORLD, Point16(44, 275), Extent16(150, 40), BUTTON_GREY,
+            WNDCreate->addButton(EditorCreateMenu, CREATE_WORLD, Position(44, 275), Extent(150, 40), BUTTON_GREY,
                                  "Create world");
             break;
 
@@ -2127,7 +2130,8 @@ void callback::EditorCreateMenu(int Param)
             else
                 width = 32;
             WNDCreate->delText(TextWidth);
-            TextWidth = WNDCreate->addText(std::to_string(width), Point16(105, 17), FontSize::Large, FontColor::Yellow);
+            TextWidth =
+              WNDCreate->addText(std::to_string(width), Position(105, 17), FontSize::Large, FontColor::Yellow);
             break;
         case REDUCE_WIDTH_16:
             if(width - 16 >= 32)
@@ -2135,7 +2139,8 @@ void callback::EditorCreateMenu(int Param)
             else
                 width = 32;
             WNDCreate->delText(TextWidth);
-            TextWidth = WNDCreate->addText(std::to_string(width), Point16(105, 17), FontSize::Large, FontColor::Yellow);
+            TextWidth =
+              WNDCreate->addText(std::to_string(width), Position(105, 17), FontSize::Large, FontColor::Yellow);
             break;
         case REDUCE_WIDTH_2:
             if(width - 2 >= 32)
@@ -2143,7 +2148,8 @@ void callback::EditorCreateMenu(int Param)
             else
                 width = 32;
             WNDCreate->delText(TextWidth);
-            TextWidth = WNDCreate->addText(std::to_string(width), Point16(105, 17), FontSize::Large, FontColor::Yellow);
+            TextWidth =
+              WNDCreate->addText(std::to_string(width), Position(105, 17), FontSize::Large, FontColor::Yellow);
             break;
         case RAISE_WIDTH_2:
             if(width + 2 <= MAXMAPWIDTH)
@@ -2151,7 +2157,8 @@ void callback::EditorCreateMenu(int Param)
             else
                 width = MAXMAPWIDTH;
             WNDCreate->delText(TextWidth);
-            TextWidth = WNDCreate->addText(std::to_string(width), Point16(105, 17), FontSize::Large, FontColor::Yellow);
+            TextWidth =
+              WNDCreate->addText(std::to_string(width), Position(105, 17), FontSize::Large, FontColor::Yellow);
             break;
         case RAISE_WIDTH_16:
             if(width + 16 <= MAXMAPWIDTH)
@@ -2159,7 +2166,8 @@ void callback::EditorCreateMenu(int Param)
             else
                 width = MAXMAPWIDTH;
             WNDCreate->delText(TextWidth);
-            TextWidth = WNDCreate->addText(std::to_string(width), Point16(105, 17), FontSize::Large, FontColor::Yellow);
+            TextWidth =
+              WNDCreate->addText(std::to_string(width), Position(105, 17), FontSize::Large, FontColor::Yellow);
             break;
         case RAISE_WIDTH_128:
             if(width + 128 <= MAXMAPWIDTH)
@@ -2167,7 +2175,8 @@ void callback::EditorCreateMenu(int Param)
             else
                 width = MAXMAPWIDTH;
             WNDCreate->delText(TextWidth);
-            TextWidth = WNDCreate->addText(std::to_string(width), Point16(105, 17), FontSize::Large, FontColor::Yellow);
+            TextWidth =
+              WNDCreate->addText(std::to_string(width), Position(105, 17), FontSize::Large, FontColor::Yellow);
             break;
         case REDUCE_HEIGHT_128:
             if(height - 128 >= 32)
@@ -2176,7 +2185,7 @@ void callback::EditorCreateMenu(int Param)
                 height = 32;
             WNDCreate->delText(TextHeight);
             TextHeight =
-              WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
+              WNDCreate->addText(std::to_string(height), Position(105, 51), FontSize::Large, FontColor::Yellow);
             break;
         case REDUCE_HEIGHT_16:
             if(height - 16 >= 32)
@@ -2185,7 +2194,7 @@ void callback::EditorCreateMenu(int Param)
                 height = 32;
             WNDCreate->delText(TextHeight);
             TextHeight =
-              WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
+              WNDCreate->addText(std::to_string(height), Position(105, 51), FontSize::Large, FontColor::Yellow);
             break;
         case REDUCE_HEIGHT_2:
             if(height - 2 >= 32)
@@ -2194,7 +2203,7 @@ void callback::EditorCreateMenu(int Param)
                 height = 32;
             WNDCreate->delText(TextHeight);
             TextHeight =
-              WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
+              WNDCreate->addText(std::to_string(height), Position(105, 51), FontSize::Large, FontColor::Yellow);
             break;
         case RAISE_HEIGHT_2:
             if(height + 2 <= MAXMAPHEIGHT)
@@ -2203,7 +2212,7 @@ void callback::EditorCreateMenu(int Param)
                 height = MAXMAPHEIGHT;
             WNDCreate->delText(TextHeight);
             TextHeight =
-              WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
+              WNDCreate->addText(std::to_string(height), Position(105, 51), FontSize::Large, FontColor::Yellow);
             break;
         case RAISE_HEIGHT_16:
             if(height + 16 <= MAXMAPHEIGHT)
@@ -2212,7 +2221,7 @@ void callback::EditorCreateMenu(int Param)
                 height = MAXMAPHEIGHT;
             WNDCreate->delText(TextHeight);
             TextHeight =
-              WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
+              WNDCreate->addText(std::to_string(height), Position(105, 51), FontSize::Large, FontColor::Yellow);
             break;
         case RAISE_HEIGHT_128:
             if(height + 128 <= MAXMAPHEIGHT)
@@ -2221,7 +2230,7 @@ void callback::EditorCreateMenu(int Param)
                 height = MAXMAPHEIGHT;
             WNDCreate->delText(TextHeight);
             TextHeight =
-              WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
+              WNDCreate->addText(std::to_string(height), Position(105, 51), FontSize::Large, FontColor::Yellow);
             break;
 
         case CHANGE_LANDSCAPE:
@@ -2230,7 +2239,7 @@ void callback::EditorCreateMenu(int Param)
                 LandscapeType = 0;
             WNDCreate->delButton(ButtonLandscape);
             ButtonLandscape = WNDCreate->addButton(
-              EditorCreateMenu, CHANGE_LANDSCAPE, Point16(64, 93), Extent16(110, 20), BUTTON_GREY,
+              EditorCreateMenu, CHANGE_LANDSCAPE, Position(64, 93), Extent(110, 20), BUTTON_GREY,
               (LandscapeType == 0 ? "Greenland" : (LandscapeType == 1 ? "Wasteland" : "Winterworld")));
             switch(LandscapeType)
             {
@@ -2250,8 +2259,8 @@ void callback::EditorCreateMenu(int Param)
             }
             WNDCreate->delStaticPicture(PicTextureIndex);
             WNDCreate->delStaticPicture(PicBorderTextureIndex);
-            PicTextureIndex = WNDCreate->addStaticPicture(Point16(102, 133), PicTextureIndexGlobal);
-            PicBorderTextureIndex = WNDCreate->addStaticPicture(Point16(102, 228), PicBorderTextureIndexGlobal);
+            PicTextureIndex = WNDCreate->addStaticPicture(Position(102, 133), PicTextureIndexGlobal);
+            PicBorderTextureIndex = WNDCreate->addStaticPicture(Position(102, 228), PicBorderTextureIndexGlobal);
             break;
 
         case TEXTURE_PREVIOUS:
@@ -2354,7 +2363,7 @@ void callback::EditorCreateMenu(int Param)
                 texture = TRIANGLE_TEXTURE_LAVA;
             }
             WNDCreate->delStaticPicture(PicTextureIndex);
-            PicTextureIndex = WNDCreate->addStaticPicture(Point16(102, 133), PicTextureIndexGlobal);
+            PicTextureIndex = WNDCreate->addStaticPicture(Position(102, 133), PicTextureIndexGlobal);
             break;
         case TEXTURE_NEXT:
             PicTextureIndexGlobal++;
@@ -2456,20 +2465,20 @@ void callback::EditorCreateMenu(int Param)
                 texture = TRIANGLE_TEXTURE_LAVA;
             }
             WNDCreate->delStaticPicture(PicTextureIndex);
-            PicTextureIndex = WNDCreate->addStaticPicture(Point16(102, 133), PicTextureIndexGlobal);
+            PicTextureIndex = WNDCreate->addStaticPicture(Position(102, 133), PicTextureIndexGlobal);
             break;
 
         case REDUCE_BORDER:
             border = std::max(0, border - 1);
             WNDCreate->delText(TextBorder);
             TextBorder =
-              WNDCreate->addText(std::to_string(border), Point16(112, 188), FontSize::Large, FontColor::Yellow);
+              WNDCreate->addText(std::to_string(border), Position(112, 188), FontSize::Large, FontColor::Yellow);
             break;
         case RAISE_BORDER:
             border = std::min(12, border + 1);
             WNDCreate->delText(TextBorder);
             TextBorder =
-              WNDCreate->addText(std::to_string(border), Point16(112, 188), FontSize::Large, FontColor::Yellow);
+              WNDCreate->addText(std::to_string(border), Position(112, 188), FontSize::Large, FontColor::Yellow);
             break;
 
         case BORDER_TEXTURE_PREVIOUS:
@@ -2572,7 +2581,7 @@ void callback::EditorCreateMenu(int Param)
                 border_texture = TRIANGLE_TEXTURE_LAVA;
             }
             WNDCreate->delStaticPicture(PicBorderTextureIndex);
-            PicBorderTextureIndex = WNDCreate->addStaticPicture(Point16(102, 228), PicBorderTextureIndexGlobal);
+            PicBorderTextureIndex = WNDCreate->addStaticPicture(Position(102, 228), PicBorderTextureIndexGlobal);
             break;
         case BORDER_TEXTURE_NEXT:
             PicBorderTextureIndexGlobal++;
@@ -2674,7 +2683,7 @@ void callback::EditorCreateMenu(int Param)
                 border_texture = TRIANGLE_TEXTURE_LAVA;
             }
             WNDCreate->delStaticPicture(PicBorderTextureIndex);
-            PicBorderTextureIndex = WNDCreate->addStaticPicture(Point16(102, 228), PicBorderTextureIndexGlobal);
+            PicBorderTextureIndex = WNDCreate->addStaticPicture(Position(102, 228), PicBorderTextureIndexGlobal);
             break;
 
         case CREATE_WORLD:
@@ -2884,18 +2893,18 @@ void callback::viewer(int Param)
               std::make_unique<CWindow>(viewer, WINDOWQUIT, Position(0, 0), Extent(250, 140), "Viewer", WINDOW_GREEN1,
                                         WINDOW_CLOSE | WINDOW_MOVE | WINDOW_RESIZE | WINDOW_MINIMIZE));
             global::s2->RegisterCallback(viewer);
-            WNDViewer->addButton(viewer, BACKWARD_100, Point16(0, 0), Extent16(35, 20), BUTTON_GREY, "100<-");
-            WNDViewer->addButton(viewer, BACKWARD_10, Point16(35, 0), Extent16(35, 20), BUTTON_GREY, "10<-");
-            WNDViewer->addButton(viewer, BACKWARD_1, Point16(70, 0), Extent16(35, 20), BUTTON_GREY, "1<-");
-            WNDViewer->addButton(viewer, FORWARD_1, Point16(105, 0), Extent16(35, 20), BUTTON_GREY, "->1");
-            WNDViewer->addButton(viewer, FORWARD_10, Point16(140, 0), Extent16(35, 20), BUTTON_GREY, "->10");
-            WNDViewer->addButton(viewer, FORWARD_100, Point16(175, 0), Extent16(35, 20), BUTTON_GREY, "->100");
+            WNDViewer->addButton(viewer, BACKWARD_100, Position(0, 0), Extent(35, 20), BUTTON_GREY, "100<-");
+            WNDViewer->addButton(viewer, BACKWARD_10, Position(35, 0), Extent(35, 20), BUTTON_GREY, "10<-");
+            WNDViewer->addButton(viewer, BACKWARD_1, Position(70, 0), Extent(35, 20), BUTTON_GREY, "1<-");
+            WNDViewer->addButton(viewer, FORWARD_1, Position(105, 0), Extent(35, 20), BUTTON_GREY, "->1");
+            WNDViewer->addButton(viewer, FORWARD_10, Position(140, 0), Extent(35, 20), BUTTON_GREY, "->10");
+            WNDViewer->addButton(viewer, FORWARD_100, Position(175, 0), Extent(35, 20), BUTTON_GREY, "->100");
             break;
 
         case CALL_FROM_GAMELOOP:
             if(PicInWndIndex >= 0)
                 WNDViewer->delStaticPicture(PicInWndIndex);
-            PicInWndIndex = WNDViewer->addStaticPicture(Point16(5, 30), index);
+            PicInWndIndex = WNDViewer->addStaticPicture(Position(5, 30), index);
 
             if(PicInfosText)
             {
@@ -2907,7 +2916,7 @@ void callback::viewer(int Param)
                 const auto infos =
                   helpers::format("index=%d, w=%d, h=%d, nx=%d, ny=%d", index, global::bmpArray[index].w,
                                   global::bmpArray[index].h, global::bmpArray[index].nx, global::bmpArray[index].ny);
-                PicInfosText = WNDViewer->addText(infos, Point16(220, 3), FontSize::Large, FontColor::Red);
+                PicInfosText = WNDViewer->addText(infos, Position(220, 3), FontSize::Large, FontColor::Red);
             }
 
             break;
@@ -3014,24 +3023,23 @@ void callback::submenu1(int Param)
     {
         case INITIALIZING_CALL:
             SubMenu = global::s2->RegisterMenu(std::make_unique<CMenu>(SPLASHSCREEN_SUBMENU1));
-            SubMenu->addButton(submenu1, MAINMENU, Point16(400, 440), Extent16(200, 20), BUTTON_RED1, "back");
-            greatMoon = SubMenu->addButton(submenu1, GREATMOON, Point16(100, 100), Extent16(200, 200), BUTTON_STONE,
+            SubMenu->addButton(submenu1, MAINMENU, Position(400, 440), Extent(200, 20), BUTTON_RED1, "back");
+            greatMoon = SubMenu->addButton(submenu1, GREATMOON, Position(100, 100), Extent(200, 200), BUTTON_STONE,
                                            nullptr, MOON);
             greatMoon->setMotionParams(GREATMOONENTRY, GREATMOONLEAVE);
-            SubMenu->addButton(submenu1, SMALLMOON, Point16(100, 350),
-                               Extent16(global::bmpArray[MOON].w, global::bmpArray[MOON].h), BUTTON_STONE, nullptr,
-                               MOON);
-            SubMenu->addButton(submenu1, TOOSMALL, Point16(100, 400),
-                               Extent16(global::bmpArray[MOON].w - 1, global::bmpArray[MOON].h - 1), BUTTON_STONE,
+            SubMenu->addButton(submenu1, SMALLMOON, Position(100, 350),
+                               Extent(global::bmpArray[MOON].w, global::bmpArray[MOON].h), BUTTON_STONE, nullptr, MOON);
+            SubMenu->addButton(submenu1, TOOSMALL, Position(100, 400),
+                               Extent(global::bmpArray[MOON].w - 1, global::bmpArray[MOON].h - 1), BUTTON_STONE,
                                nullptr, MOON);
-            SubMenu->addButton(submenu1, CREATEWINDOW, Point16(500, 10), Extent16(130, 30), BUTTON_GREEN1,
+            SubMenu->addButton(submenu1, CREATEWINDOW, Position(500, 10), Extent(130, 30), BUTTON_GREEN1,
                                "Create window");
-            picObject = SubMenu->addPicture(submenu1, PICOBJECT, Point16(200, 30), MIS0BOBS_SHIP);
+            picObject = SubMenu->addPicture(submenu1, PICOBJECT, Position(200, 30), MIS0BOBS_SHIP);
             picObject->setMotionParams(PICOBJECTENTRY, PICOBJECTLEAVE);
             // text block with \n
-            SubMenu->addText("\nTextblock:\n\nNeue Zeile\nNoch eine neue Zeile", Point16(400, 200), FontSize::Large);
-            testTextfield = SubMenu->addTextfield(Point16(400, 300), 10, 3);
-            testSelectBox = SubMenu->addSelectBox(Point16(500, 500), Extent16(300, 200));
+            SubMenu->addText("\nTextblock:\n\nNeue Zeile\nNoch eine neue Zeile", Position(400, 200), FontSize::Large);
+            testTextfield = SubMenu->addTextfield(Position(400, 300), 10, 3);
+            testSelectBox = SubMenu->addSelectBox(Position(500, 500), Extent(300, 200));
             testSelectBox->addOption("Erste Option", submenu1, SELECTBOX_OPTION1);
             testSelectBox->addOption("Zweite Option", submenu1, SELECTBOX_OPTION2);
             testSelectBox->addOption("Dritte Option", submenu1, SELECTBOX_OPTION3);
@@ -3065,10 +3073,10 @@ void callback::submenu1(int Param)
             break;
 
         case GREATMOON:
-            SubMenu->addText("Title!", Point16(300, 10), FontSize::Large);
+            SubMenu->addText("Title!", Position(300, 10), FontSize::Large);
             SubMenu->addText(
               helpers::format("Window X: %d Window Y: %d", global::s2->GameResolution.x, global::s2->GameResolution.y),
-              Point16(10, 10), FontSize::Large);
+              Position(10, 10), FontSize::Large);
             break;
 
         case SMALLMOON:
@@ -3079,7 +3087,7 @@ void callback::submenu1(int Param)
 
         case TOOSMALL:
             if(picIndex == -1)
-                picIndex = SubMenu->addStaticPicture(Point16(0, 0), MAINFRAME_640_480);
+                picIndex = SubMenu->addStaticPicture(Position(0, 0), MAINFRAME_640_480);
             break;
 
         case CREATEWINDOW:
@@ -3088,14 +3096,14 @@ void callback::submenu1(int Param)
                 testWindow = global::s2->RegisterWindow(std::make_unique<CWindow>(
                   submenu1, TESTWINDOWQUITMESSAGE, Position(5, 5), Extent(350, 240), "Window", WINDOW_GREEN1,
                   WINDOW_CLOSE | WINDOW_MOVE | WINDOW_MINIMIZE | WINDOW_RESIZE));
-                testWindow->addText("Text inside the window", Point16(10, 10), FontSize::Large);
-                testWindow->addButton(submenu1, -10, Point16(150, 100), Extent16(210, 30), BUTTON_GREEN2,
+                testWindow->addText("Text inside the window", Position(10, 10), FontSize::Large);
+                testWindow->addButton(submenu1, -10, Position(150, 100), Extent(210, 30), BUTTON_GREEN2,
                                       "Button inside the window");
                 testWindowPicture =
-                  testWindow->addPicture(submenu1, TESTWINDOWPICTURE, Point16(10, 60), MIS2BOBS_FORTRESS);
+                  testWindow->addPicture(submenu1, TESTWINDOWPICTURE, Position(10, 60), MIS2BOBS_FORTRESS);
                 testWindowPicture->setMotionParams(TESTWINDOWPICTUREENTRY, TESTWINDOWPICTURELEAVE);
-                testTextfield_testWindow =
-                  testWindow->addTextfield(Point16(130, 30), 10, 3, FontSize::Large, FontColor::Red, BUTTON_GREY, true);
+                testTextfield_testWindow = testWindow->addTextfield(Position(130, 30), 10, 3, FontSize::Large,
+                                                                    FontColor::Red, BUTTON_GREY, true);
                 testTextfield_testWindow->setText(
                   "This is a very long test text in order to destroy the text field completely once and for all");
             }
@@ -3104,14 +3112,14 @@ void callback::submenu1(int Param)
                 testWindow2 = global::s2->RegisterWindow(std::make_unique<CWindow>(
                   submenu1, TESTWINDOW2QUITMESSAGE, Position(200, 5), Extent(350, 240), "Another Window", WINDOW_GREEN1,
                   WINDOW_CLOSE | WINDOW_MOVE | WINDOW_MINIMIZE | WINDOW_RESIZE));
-                testWindow2->addText("Text inside the window", Point16(50, 40), FontSize::Small);
-                testWindow2->addButton(submenu1, -10, Point16(100, 100), Extent16(100, 20), BUTTON_GREEN2, "Button");
+                testWindow2->addText("Text inside the window", Position(50, 40), FontSize::Small);
+                testWindow2->addButton(submenu1, -10, Position(100, 100), Extent(100, 20), BUTTON_GREEN2, "Button");
             }
             break;
 
         case GREATMOONENTRY:
             if(!greatMoonText)
-                greatMoonText = SubMenu->addText("Test-Text", Point16(100, 10), FontSize::Large);
+                greatMoonText = SubMenu->addText("Test-Text", Position(100, 10), FontSize::Large);
             break;
 
         case GREATMOONLEAVE:
@@ -3132,7 +3140,7 @@ void callback::submenu1(int Param)
 
         case PICOBJECTENTRY:
             if(!greatMoonText)
-                greatMoonText = SubMenu->addText("Test-Text", Point16(100, 10), FontSize::Large);
+                greatMoonText = SubMenu->addText("Test-Text", Position(100, 10), FontSize::Large);
             break;
 
         case PICOBJECTLEAVE:
@@ -3146,7 +3154,7 @@ void callback::submenu1(int Param)
         case TESTWINDOWPICTURE:
             assert(testWindow);
             if(!testWindowText)
-                testWindowText = testWindow->addText("Clicked on castle", Point16(10, 200), FontSize::Medium);
+                testWindowText = testWindow->addText("Clicked on castle", Position(10, 200), FontSize::Medium);
             else
             {
                 testWindow->delText(testWindowText);
@@ -3161,7 +3169,7 @@ void callback::submenu1(int Param)
                 testWindow->delText(testWindowText2);
                 testWindowText2 = nullptr;
             }
-            testWindowText2 = testWindow->addText("Bildbereich betreten", Point16(10, 220), FontSize::Medium);
+            testWindowText2 = testWindow->addText("Bildbereich betreten", Position(10, 220), FontSize::Medium);
             break;
 
         case TESTWINDOWPICTURELEAVE:
@@ -3171,7 +3179,7 @@ void callback::submenu1(int Param)
                 testWindow->delText(testWindowText2);
                 testWindowText2 = nullptr;
             }
-            testWindowText2 = testWindow->addText("Bildbereich verlassen", Point16(10, 220), FontSize::Medium);
+            testWindowText2 = testWindow->addText("Bildbereich verlassen", Position(10, 220), FontSize::Medium);
             break;
 
         case TESTWINDOWQUITMESSAGE:
@@ -3197,7 +3205,7 @@ void callback::submenu1(int Param)
                 if(!counterText)
                 {
                     counterText =
-                      SubMenu->addText(helpers::format("counter: %d", counter), Point16(100, 20), FontSize::Small);
+                      SubMenu->addText(helpers::format("counter: %d", counter), Position(100, 20), FontSize::Small);
                 }
 
                 if(TextFrom_testTextfield)
@@ -3206,7 +3214,7 @@ void callback::submenu1(int Param)
                     TextFrom_testTextfield = nullptr;
                 }
                 TextFrom_testTextfield = SubMenu->addText("Der Text im Textfeld lautet: " + testTextfield->getText(),
-                                                          Point16(200, 400), FontSize::Large);
+                                                          Position(200, 400), FontSize::Large);
             }
             counter++;
             break;

--- a/callbacks.cpp
+++ b/callbacks.cpp
@@ -239,21 +239,21 @@ void callback::submenuOptions(int Param)
         case INITIALIZING_CALL:
             SubMenu = global::s2->RegisterMenu(std::make_unique<CMenu>(SPLASHSCREEN_SUBMENU3));
             // add button for "back to main menu"
-            SubMenu->addButton(submenuOptions, MAINMENU, Point16((int)(global::s2->GameResolution.x / 2 - 100), 440),
+            SubMenu->addButton(submenuOptions, MAINMENU, Point16(static_cast<int>(global::s2->GameResolution.x / 2 - 100), 440),
                                Extent16(200, 20), BUTTON_RED1, "back");
             // add menu title
-            SubMenu->addText("Options", Point16((int)(global::s2->GameResolution.x / 2 - 20), 10), FontSize::Large);
+            SubMenu->addText("Options", Point16(static_cast<int>(global::s2->GameResolution.x / 2 - 20), 10), FontSize::Large);
             // add screen resolution
             if(TextResolution)
                 SubMenu->delText(TextResolution);
             TextResolution = SubMenu->addText(
               helpers::format("Game Resolution: %d*%d / %s", global::s2->GameResolution.x, global::s2->GameResolution.y,
                               (global::s2->fullscreen ? "Fullscreen" : "Window")),
-              Point16((int)(global::s2->GameResolution.x / 2 - 110), 50), FontSize::Medium);
+              Point16(static_cast<int>(global::s2->GameResolution.x / 2 - 110), 50), FontSize::Medium);
             if(ButtonFullscreen)
                 SubMenu->delButton(ButtonFullscreen);
             ButtonFullscreen = SubMenu->addButton(
-              submenuOptions, FULLSCREEN, Point16((int)(global::s2->GameResolution.x / 2 - 100), 190),
+              submenuOptions, FULLSCREEN, Point16(static_cast<int>(global::s2->GameResolution.x / 2 - 100), 190),
               Extent16(200, 20), BUTTON_RED1, (global::s2->fullscreen ? "WINDOW" : "FULLSCREEN"));
             SelectBoxRes = SubMenu->addSelectBox(ButtonFullscreen->getPos() - Point16(0, 120), Extent16(200, 110),
                                                  FontSize::Medium, FontColor::Yellow, BUTTON_GREY);

--- a/callbacks.cpp
+++ b/callbacks.cpp
@@ -46,7 +46,7 @@ void callback::PleaseWait(int Param)
             // we don't register this window cause we will destroy it manually if we need
             // global::s2->RegisterCallback(PleaseWait);
 
-            WNDWait->addText("Please wait ...", 10, 10, FontSize::Large);
+            WNDWait->addText("Please wait ...", Point16(10, 10), FontSize::Large);
             // we need to render this window NOW, cause the render loop will do it too late (when the operation
             // is done and we don't need the "Please wait"-window anymore)
             CSurface::Draw(global::s2->getDisplaySurface(), WNDWait->getSurface(),
@@ -99,7 +99,7 @@ void callback::ShowStatus(int Param)
             WND = global::s2->RegisterWindow(std::make_unique<CWindow>(ShowStatus, WINDOWQUIT, WindowPos::Center,
                                                                        Extent(250, 90), "Status", WINDOW_GREEN1,
                                                                        WINDOW_CLOSE | WINDOW_MINIMIZE | WINDOW_MOVE));
-            txt = WND->addText("", 26, 20, FontSize::Large, FontColor::Yellow);
+            txt = WND->addText("", Point16(26, 20), FontSize::Large, FontColor::Yellow);
             break;
         case SHOW_SUCCESS:
             assert(txt);
@@ -140,12 +140,12 @@ void callback::mainmenu(int Param)
     {
         case INITIALIZING_CALL:
             MainMenu = global::s2->RegisterMenu(std::make_unique<CMenu>(SPLASHSCREEN_MAINMENU));
-            MainMenu->addButton(mainmenu, ENDGAME, 50, 400, 200, 20, BUTTON_RED1, "Quit program");
+            MainMenu->addButton(mainmenu, ENDGAME, Point16(50, 400), Extent16(200, 20), BUTTON_RED1, "Quit program");
 #ifdef _ADMINMODE
-            MainMenu->addButton(submenu1, INITIALIZING_CALL, 50, 200, 200, 20, BUTTON_GREY, "Submenu_1");
+            MainMenu->addButton(submenu1, INITIALIZING_CALL, Point16(50, 200), Extent16(200, 20), BUTTON_GREY, "Submenu_1");
 #endif
-            MainMenu->addButton(mainmenu, STARTEDITOR, 50, 160, 200, 20, BUTTON_RED1, "Start editor");
-            MainMenu->addButton(mainmenu, OPTIONS, 50, 370, 200, 20, BUTTON_GREEN2, "Options");
+            MainMenu->addButton(mainmenu, STARTEDITOR, Point16(50, 160), Extent16(200, 20), BUTTON_RED1, "Start editor");
+            MainMenu->addButton(mainmenu, OPTIONS, Point16(50, 370), Extent16(200, 20), BUTTON_GREEN2, "Options");
             break;
 
         case CALL_FROM_GAMELOOP: break;
@@ -237,22 +237,22 @@ void callback::submenuOptions(int Param)
         case INITIALIZING_CALL:
             SubMenu = global::s2->RegisterMenu(std::make_unique<CMenu>(SPLASHSCREEN_SUBMENU3));
             // add button for "back to main menu"
-            SubMenu->addButton(submenuOptions, MAINMENU, (int)(global::s2->GameResolution.x / 2 - 100), 440, 200, 20,
-                               BUTTON_RED1, "back");
+            SubMenu->addButton(submenuOptions, MAINMENU, Point16((int)(global::s2->GameResolution.x / 2 - 100), 440),
+                               Extent16(200, 20), BUTTON_RED1, "back");
             // add menu title
-            SubMenu->addText("Options", (int)(global::s2->GameResolution.x / 2 - 20), 10, FontSize::Large);
+            SubMenu->addText("Options", Point16((int)(global::s2->GameResolution.x / 2 - 20), 10), FontSize::Large);
             // add screen resolution
             if(TextResolution)
                 SubMenu->delText(TextResolution);
             TextResolution = SubMenu->addText(
               helpers::format("Game Resolution: %d*%d / %s", global::s2->GameResolution.x, global::s2->GameResolution.y,
                               (global::s2->fullscreen ? "Fullscreen" : "Window")),
-              (int)(global::s2->GameResolution.x / 2 - 110), 50, FontSize::Medium);
+              Point16((int)(global::s2->GameResolution.x / 2 - 110), 50), FontSize::Medium);
             if(ButtonFullscreen)
                 SubMenu->delButton(ButtonFullscreen);
             ButtonFullscreen =
-              SubMenu->addButton(submenuOptions, FULLSCREEN, (int)(global::s2->GameResolution.x / 2 - 100), 190, 200,
-                                 20, BUTTON_RED1, (global::s2->fullscreen ? "WINDOW" : "FULLSCREEN"));
+              SubMenu->addButton(submenuOptions, FULLSCREEN, Point16((int)(global::s2->GameResolution.x / 2 - 100), 190),
+                                 Extent16(200, 20), BUTTON_RED1, (global::s2->fullscreen ? "WINDOW" : "FULLSCREEN"));
             SelectBoxRes = SubMenu->addSelectBox(ButtonFullscreen->getPos() - Point16(0, 120), Extent16(200, 110),
                                                  FontSize::Medium, FontColor::Yellow, BUTTON_GREY);
             SelectBoxRes->addOption("800 x 600 (SVGA)", submenuOptions, SELECTBOX_800_600);
@@ -713,10 +713,10 @@ void callback::EditorMainMenu(int Param)
             WNDMain = global::s2->RegisterWindow(std::make_unique<CWindow>(EditorMainMenu, WINDOWQUIT,
                                                                            WindowPos::Center, Extent(220, 320),
                                                                            "Main menu", WINDOW_GREEN1, WINDOW_CLOSE));
-            WNDMain->addButton(EditorMainMenu, LOADMENU, 8, 100, 190, 20, BUTTON_GREEN2, "Load map");
-            WNDMain->addButton(EditorMainMenu, SAVEMENU, 8, 125, 190, 20, BUTTON_GREEN2, "Save map");
+            WNDMain->addButton(EditorMainMenu, LOADMENU, Point16(8, 100), Extent16(190, 20), BUTTON_GREEN2, "Load map");
+            WNDMain->addButton(EditorMainMenu, SAVEMENU, Point16(8, 125), Extent16(190, 20), BUTTON_GREEN2, "Save map");
 
-            WNDMain->addButton(EditorMainMenu, QUITMENU, 8, 260, 190, 20, BUTTON_GREEN2, "Leave editor");
+            WNDMain->addButton(EditorMainMenu, QUITMENU, Point16(8, 260), Extent16(190, 20), BUTTON_GREEN2, "Leave editor");
             break;
 
         case WINDOWQUIT:
@@ -770,8 +770,8 @@ void callback::EditorLoadMenu(int Param)
                     CB_Filename->addOption(filename, [filename](int) { curFilename = filename; });
                 }
             }
-            WNDLoad->addButton(EditorLoadMenu, LOADMAP, 175, 140, 90, 20, BUTTON_GREY, "Load");
-            WNDLoad->addButton(EditorLoadMenu, WINDOWQUIT, 175, 165, 90, 20, BUTTON_RED1, "Abort");
+            WNDLoad->addButton(EditorLoadMenu, LOADMAP, Point16(175, 140), Extent16(90, 20), BUTTON_GREY, "Load");
+            WNDLoad->addButton(EditorLoadMenu, WINDOWQUIT, Point16(175, 165), Extent16(90, 20), BUTTON_RED1, "Abort");
             break;
         }
         case WINDOWQUIT:
@@ -855,18 +855,18 @@ void callback::EditorSaveMenu(int Param)
                                                                                "Save", WINDOW_GREEN1, WINDOW_CLOSE));
                 MapObj = global::s2->getMapObj();
 
-                WNDSave->addText("Filename", 100, 2, FontSize::Small);
-                TXTF_Filename = WNDSave->addTextfield(10, 13, 21, 1);
+                WNDSave->addText("Filename", Point16(100, 2), FontSize::Small);
+                TXTF_Filename = WNDSave->addTextfield(Point16(10, 13), 21, 1);
                 const bfs::path filePath = MapObj->getFilepath().empty() ? "MyMap" : MapObj->getFilepath();
                 TXTF_Filename->setText(filePath.filename().string());
-                WNDSave->addText("Mapname", 98, 38, FontSize::Small);
-                TXTF_Mapname = WNDSave->addTextfield(10, 50, 19, 1);
+                WNDSave->addText("Mapname", Point16(98, 38), FontSize::Small);
+                TXTF_Mapname = WNDSave->addTextfield(Point16(10, 50), 19, 1);
                 TXTF_Mapname->setText(MapObj->getMapname());
-                WNDSave->addText("Author", 110, 75, FontSize::Medium);
-                TXTF_Author = WNDSave->addTextfield(10, 87, 19, 1);
+                WNDSave->addText("Author", Point16(110, 75), FontSize::Medium);
+                TXTF_Author = WNDSave->addTextfield(Point16(10, 87), 19, 1);
                 TXTF_Author->setText(MapObj->getAuthor());
-                WNDSave->addButton(EditorSaveMenu, SAVEMAP, 170, 120, 90, 20, BUTTON_GREY, "Save");
-                WNDSave->addButton(EditorSaveMenu, WINDOWQUIT, 170, 145, 90, 20, BUTTON_RED1, "Abort");
+                WNDSave->addButton(EditorSaveMenu, SAVEMAP, Point16(170, 120), Extent16(90, 20), BUTTON_GREY, "Save");
+                WNDSave->addButton(EditorSaveMenu, WINDOWQUIT, Point16(170, 145), Extent16(90, 20), BUTTON_RED1, "Abort");
                 break;
             }
         case WINDOWQUIT:
@@ -923,10 +923,8 @@ void callback::EditorQuitMenu(int Param)
                 break;
             WNDBackToMainMenu = global::s2->RegisterWindow(
               std::make_unique<CWindow>(EditorQuitMenu, WINDOWQUIT, WindowPos::Center, Extent(212, 110), "Exit?"));
-            WNDBackToMainMenu->addButton(EditorQuitMenu, BACKTOMAIN, 0, 0, 100, 80, BUTTON_GREEN2, nullptr,
-                                         PICTURE_SMALL_TICK);
-            WNDBackToMainMenu->addButton(EditorQuitMenu, NOTBACKTOMAIN, 100, 0, 100, 80, BUTTON_RED1, nullptr,
-                                         PICTURE_SMALL_CROSS);
+            WNDBackToMainMenu->addButton(EditorQuitMenu, BACKTOMAIN, Point16(0, 0), Extent16(100, 80), BUTTON_GREEN2, nullptr, PICTURE_SMALL_TICK);
+            WNDBackToMainMenu->addButton(EditorQuitMenu, NOTBACKTOMAIN, Point16(100, 0), Extent16(100, 80), BUTTON_RED1, nullptr, PICTURE_SMALL_CROSS);
             break;
 
         case BACKTOMAIN:
@@ -1021,24 +1019,24 @@ void callback::EditorTextureMenu(int Param)
             MapObj->setMode(EDITOR_MODE_TEXTURE);
             MapObj->setModeContent(TRIANGLE_TEXTURE_SNOW);
 
-            WNDTexture->addPicture(EditorTextureMenu, PICSNOW, 2, 2, textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICSTEPPE, 36, 2, textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICSWAMP, 70, 2, textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICFLOWER, 104, 2, textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICMINING1, 138, 2, textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICMINING2, 172, 2, textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICMINING3, 2, 36, textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICMINING4, 36, 36, textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICSTEPPE_MEADOW1, 70, 36, textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICMEADOW1, 104, 36, textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICMEADOW2, 138, 36, textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICMEADOW3, 172, 36, textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICSTEPPE_MEADOW2, 2, 70, textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICMINING_MEADOW, 36, 70, textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICWATER, 70, 70, textureIndex++);
-            WNDTexture->addPicture(EditorTextureMenu, PICLAVA, 104, 70, textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICSNOW, Point16(2, 2), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICSTEPPE, Point16(36, 2), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICSWAMP, Point16(70, 2), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICFLOWER, Point16(104, 2), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICMINING1, Point16(138, 2), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICMINING2, Point16(172, 2), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICMINING3, Point16(2, 36), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICMINING4, Point16(36, 36), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICSTEPPE_MEADOW1, Point16(70, 36), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICMEADOW1, Point16(104, 36), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICMEADOW2, Point16(138, 36), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICMEADOW3, Point16(172, 36), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICSTEPPE_MEADOW2, Point16(2, 70), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICMINING_MEADOW, Point16(36, 70), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICWATER, Point16(70, 70), textureIndex++);
+            WNDTexture->addPicture(EditorTextureMenu, PICLAVA, Point16(104, 70), textureIndex++);
             if(map->type != MAP_WASTELAND)
-                WNDTexture->addPicture(EditorTextureMenu, PICMEADOW_MIXED, 138, 70, textureIndex);
+                WNDTexture->addPicture(EditorTextureMenu, PICMEADOW_MIXED, Point16(138, 70), textureIndex);
             break;
 
         case PICSNOW: MapObj->setModeContent(TRIANGLE_TEXTURE_SNOW); break;
@@ -1145,30 +1143,30 @@ void callback::EditorTreeMenu(int Param)
             switch(map->type)
             {
                 case MAP_GREENLAND:
-                    WNDTree->addPicture(EditorTreeMenu, PICPINE, 2, 2, PICTURE_TREE_PINE);
-                    WNDTree->addPicture(EditorTreeMenu, PICBIRCH, 36, 2, PICTURE_TREE_BIRCH);
-                    WNDTree->addPicture(EditorTreeMenu, PICOAK, 70, 2, PICTURE_TREE_OAK);
-                    WNDTree->addPicture(EditorTreeMenu, PICPALM1, 104, 2, PICTURE_TREE_PALM1);
-                    WNDTree->addPicture(EditorTreeMenu, PICPALM2, 2, 36, PICTURE_TREE_PALM2);
-                    WNDTree->addPicture(EditorTreeMenu, PICPINEAPPLE, 36, 36, PICTURE_TREE_PINEAPPLE);
-                    WNDTree->addPicture(EditorTreeMenu, PICCYPRESS, 70, 36, PICTURE_TREE_CYPRESS);
-                    WNDTree->addPicture(EditorTreeMenu, PICCHERRY, 104, 36, PICTURE_TREE_CHERRY);
-                    WNDTree->addPicture(EditorTreeMenu, PICFIR, 2, 72, PICTURE_TREE_FIR);
-                    WNDTree->addPicture(EditorTreeMenu, PICWOOD_MIXED, 36, 70, PICTURE_TREE_WOOD_MIXED);
-                    WNDTree->addPicture(EditorTreeMenu, PICPALM_MIXED, 70, 70, PICTURE_TREE_PALM_MIXED);
+                    WNDTree->addPicture(EditorTreeMenu, PICPINE, Point16(2, 2), PICTURE_TREE_PINE);
+                    WNDTree->addPicture(EditorTreeMenu, PICBIRCH, Point16(36, 2), PICTURE_TREE_BIRCH);
+                    WNDTree->addPicture(EditorTreeMenu, PICOAK, Point16(70, 2), PICTURE_TREE_OAK);
+                    WNDTree->addPicture(EditorTreeMenu, PICPALM1, Point16(104, 2), PICTURE_TREE_PALM1);
+                    WNDTree->addPicture(EditorTreeMenu, PICPALM2, Point16(2, 36), PICTURE_TREE_PALM2);
+                    WNDTree->addPicture(EditorTreeMenu, PICPINEAPPLE, Point16(36, 36), PICTURE_TREE_PINEAPPLE);
+                    WNDTree->addPicture(EditorTreeMenu, PICCYPRESS, Point16(70, 36), PICTURE_TREE_CYPRESS);
+                    WNDTree->addPicture(EditorTreeMenu, PICCHERRY, Point16(104, 36), PICTURE_TREE_CHERRY);
+                    WNDTree->addPicture(EditorTreeMenu, PICFIR, Point16(2, 72), PICTURE_TREE_FIR);
+                    WNDTree->addPicture(EditorTreeMenu, PICWOOD_MIXED, Point16(36, 70), PICTURE_TREE_WOOD_MIXED);
+                    WNDTree->addPicture(EditorTreeMenu, PICPALM_MIXED, Point16(70, 70), PICTURE_TREE_PALM_MIXED);
                     break;
                 case MAP_WASTELAND:
-                    WNDTree->addPicture(EditorTreeMenu, PICFLAPHAT, 2, 2, PICTURE_TREE_FLAPHAT);
-                    WNDTree->addPicture(EditorTreeMenu, PICSPIDER, 36, 2, PICTURE_TREE_SPIDER);
-                    WNDTree->addPicture(EditorTreeMenu, PICPINEAPPLE, 70, 2, PICTURE_TREE_PINEAPPLE);
-                    WNDTree->addPicture(EditorTreeMenu, PICCHERRY, 104, 2, PICTURE_TREE_CHERRY);
+                    WNDTree->addPicture(EditorTreeMenu, PICFLAPHAT, Point16(2, 2), PICTURE_TREE_FLAPHAT);
+                    WNDTree->addPicture(EditorTreeMenu, PICSPIDER, Point16(36, 2), PICTURE_TREE_SPIDER);
+                    WNDTree->addPicture(EditorTreeMenu, PICPINEAPPLE, Point16(70, 2), PICTURE_TREE_PINEAPPLE);
+                    WNDTree->addPicture(EditorTreeMenu, PICCHERRY, Point16(104, 2), PICTURE_TREE_CHERRY);
                     break;
                 case MAP_WINTERLAND:
-                    WNDTree->addPicture(EditorTreeMenu, PICPINE, 2, 2, PICTURE_TREE_PINE);
-                    WNDTree->addPicture(EditorTreeMenu, PICBIRCH, 36, 2, PICTURE_TREE_BIRCH);
-                    WNDTree->addPicture(EditorTreeMenu, PICCYPRESS, 70, 2, PICTURE_TREE_CYPRESS);
-                    WNDTree->addPicture(EditorTreeMenu, PICFIR, 104, 2, PICTURE_TREE_FIR);
-                    WNDTree->addPicture(EditorTreeMenu, PICWOOD_MIXED, 2, 36, PICTURE_TREE_WOOD_MIXED);
+                    WNDTree->addPicture(EditorTreeMenu, PICPINE, Point16(2, 2), PICTURE_TREE_PINE);
+                    WNDTree->addPicture(EditorTreeMenu, PICBIRCH, Point16(36, 2), PICTURE_TREE_BIRCH);
+                    WNDTree->addPicture(EditorTreeMenu, PICCYPRESS, Point16(70, 2), PICTURE_TREE_CYPRESS);
+                    WNDTree->addPicture(EditorTreeMenu, PICFIR, Point16(104, 2), PICTURE_TREE_FIR);
+                    WNDTree->addPicture(EditorTreeMenu, PICWOOD_MIXED, Point16(2, 36), PICTURE_TREE_WOOD_MIXED);
                     break;
                 default: // should not happen
                     break;
@@ -1331,10 +1329,10 @@ void callback::EditorResourceMenu(int Param)
                                         WINDOW_GREEN1, WINDOW_CLOSE | WINDOW_MINIMIZE | WINDOW_MOVE));
             MapObj = global::s2->getMapObj();
 
-            WNDResource->addPicture(EditorResourceMenu, PICGOLD, 2, 2, PICTURE_RESOURCE_GOLD);
-            WNDResource->addPicture(EditorResourceMenu, PICORE, 36, 2, PICTURE_RESOURCE_ORE);
-            WNDResource->addPicture(EditorResourceMenu, PICCOAL, 70, 2, PICTURE_RESOURCE_COAL);
-            WNDResource->addPicture(EditorResourceMenu, PICGRANITE, 104, 2, PICTURE_RESOURCE_GRANITE);
+            WNDResource->addPicture(EditorResourceMenu, PICGOLD, Point16(2, 2), PICTURE_RESOURCE_GOLD);
+            WNDResource->addPicture(EditorResourceMenu, PICORE, Point16(36, 2), PICTURE_RESOURCE_ORE);
+            WNDResource->addPicture(EditorResourceMenu, PICCOAL, Point16(70, 2), PICTURE_RESOURCE_COAL);
+            WNDResource->addPicture(EditorResourceMenu, PICGRANITE, Point16(104, 2), PICTURE_RESOURCE_GRANITE);
 
             MapObj->setMode(EDITOR_MODE_RESOURCE_RAISE);
             MapObj->setModeContent(0x51);
@@ -1436,39 +1434,37 @@ void callback::EditorLandscapeMenu(int Param)
             switch(map->type)
             {
                 case MAP_GREENLAND:
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICGRANITE, 2, 2, PICTURE_LANDSCAPE_GRANITE);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICTREEDEAD, 36, 2, PICTURE_LANDSCAPE_TREE_DEAD);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSTONE, 70, 2, PICTURE_LANDSCAPE_STONE);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICCACTUS, 2, 36, PICTURE_LANDSCAPE_CACTUS);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICPEBBLE, 36, 36, PICTURE_LANDSCAPE_PEBBLE);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICBUSH, 70, 36, PICTURE_LANDSCAPE_BUSH);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSHRUB, 2, 70, PICTURE_LANDSCAPE_SHRUB);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICBONE, 36, 70, PICTURE_LANDSCAPE_BONE);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICMUSHROOM, 70, 70, PICTURE_LANDSCAPE_MUSHROOM);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICFLOWERS, 5, 107, MAPPIC_FLOWERS);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICGRANITE, Point16(2, 2), PICTURE_LANDSCAPE_GRANITE);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICTREEDEAD, Point16(36, 2), PICTURE_LANDSCAPE_TREE_DEAD);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSTONE, Point16(70, 2), PICTURE_LANDSCAPE_STONE);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICCACTUS, Point16(2, 36), PICTURE_LANDSCAPE_CACTUS);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICPEBBLE, Point16(36, 36), PICTURE_LANDSCAPE_PEBBLE);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICBUSH, Point16(70, 36), PICTURE_LANDSCAPE_BUSH);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSHRUB, Point16(2, 70), PICTURE_LANDSCAPE_SHRUB);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICBONE, Point16(36, 70), PICTURE_LANDSCAPE_BONE);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICMUSHROOM, Point16(70, 70), PICTURE_LANDSCAPE_MUSHROOM);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICFLOWERS, Point16(5, 107), MAPPIC_FLOWERS);
                     break;
                 case MAP_WASTELAND:
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICGRANITE, 2, 2, PICTURE_LANDSCAPE_GRANITE);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICTREEDEAD, 36, 2, PICTURE_LANDSCAPE_TREE_DEAD);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSTONE, 70, 2, PICTURE_LANDSCAPE_STONE);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSTALAGMITE, 2, 36, PICTURE_LANDSCAPE_STALAGMITE);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICPEBBLE, 36, 36, PICTURE_LANDSCAPE_PEBBLE);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICBUSH, 70, 36, PICTURE_LANDSCAPE_BUSH);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSHRUB, 2, 70, PICTURE_LANDSCAPE_SHRUB);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICBONE, 36, 70, PICTURE_LANDSCAPE_BONE);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICMUSHROOM, 70, 70, PICTURE_LANDSCAPE_MUSHROOM);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICFLOWERS, 5, 107, MAPPIC_FLOWERS);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICGRANITE, Point16(2, 2), PICTURE_LANDSCAPE_GRANITE);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICTREEDEAD, Point16(36, 2), PICTURE_LANDSCAPE_TREE_DEAD);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSTONE, Point16(70, 2), PICTURE_LANDSCAPE_STONE);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSTALAGMITE, Point16(2, 36), PICTURE_LANDSCAPE_STALAGMITE);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICPEBBLE, Point16(36, 36), PICTURE_LANDSCAPE_PEBBLE);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICBUSH, Point16(70, 36), PICTURE_LANDSCAPE_BUSH);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSHRUB, Point16(2, 70), PICTURE_LANDSCAPE_SHRUB);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICBONE, Point16(36, 70), PICTURE_LANDSCAPE_BONE);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICMUSHROOM, Point16(70, 70), PICTURE_LANDSCAPE_MUSHROOM);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICFLOWERS, Point16(5, 107), MAPPIC_FLOWERS);
                     break;
                 case MAP_WINTERLAND:
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICGRANITE, 2, 2, PICTURE_LANDSCAPE_GRANITE_WINTER);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICTREEDEAD, 36, 2,
-                                             PICTURE_LANDSCAPE_TREE_DEAD_WINTER);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSTONE, 70, 2, PICTURE_LANDSCAPE_STONE_WINTER);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICPEBBLE, 2, 36, PICTURE_LANDSCAPE_PEBBLE_WINTER);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICBONE, 36, 36, PICTURE_LANDSCAPE_BONE_WINTER);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICMUSHROOM, 70, 36,
-                                             PICTURE_LANDSCAPE_MUSHROOM_WINTER);
-                    WNDLandscape->addPicture(EditorLandscapeMenu, PICFLOWERS, 73, 73, MAPPIC_FLOWERS);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICGRANITE, Point16(2, 2), PICTURE_LANDSCAPE_GRANITE_WINTER);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICTREEDEAD, Point16(36, 2), PICTURE_LANDSCAPE_TREE_DEAD_WINTER);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICSTONE, Point16(70, 2), PICTURE_LANDSCAPE_STONE_WINTER);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICPEBBLE, Point16(2, 36), PICTURE_LANDSCAPE_PEBBLE_WINTER);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICBONE, Point16(36, 36), PICTURE_LANDSCAPE_BONE_WINTER);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICMUSHROOM, Point16(70, 36), PICTURE_LANDSCAPE_MUSHROOM_WINTER);
+                    WNDLandscape->addPicture(EditorLandscapeMenu, PICFLOWERS, Point16(73, 73), MAPPIC_FLOWERS);
                     break;
                 default: // should not happen
                     break;
@@ -1619,12 +1615,12 @@ void callback::EditorAnimalMenu(int Param)
             WNDAnimal = global::s2->RegisterWindow(
               std::make_unique<CWindow>(EditorAnimalMenu, WINDOWQUIT, Pos, Extent(116, 106), "Animals", WINDOW_GREEN1,
                                         WINDOW_CLOSE | WINDOW_MINIMIZE | WINDOW_MOVE));
-            WNDAnimal->addPicture(EditorAnimalMenu, PICRABBIT, 2, 2, PICTURE_ANIMAL_RABBIT);
-            WNDAnimal->addPicture(EditorAnimalMenu, PICFOX, 36, 2, PICTURE_ANIMAL_FOX);
-            WNDAnimal->addPicture(EditorAnimalMenu, PICSTAG, 70, 2, PICTURE_ANIMAL_STAG);
-            WNDAnimal->addPicture(EditorAnimalMenu, PICROE, 2, 36, PICTURE_ANIMAL_ROE);
-            WNDAnimal->addPicture(EditorAnimalMenu, PICDUCK, 36, 36, PICTURE_ANIMAL_DUCK);
-            WNDAnimal->addPicture(EditorAnimalMenu, PICSHEEP, 70, 36, PICTURE_ANIMAL_SHEEP);
+            WNDAnimal->addPicture(EditorAnimalMenu, PICRABBIT, Point16(2, 2), PICTURE_ANIMAL_RABBIT);
+            WNDAnimal->addPicture(EditorAnimalMenu, PICFOX, Point16(36, 2), PICTURE_ANIMAL_FOX);
+            WNDAnimal->addPicture(EditorAnimalMenu, PICSTAG, Point16(70, 2), PICTURE_ANIMAL_STAG);
+            WNDAnimal->addPicture(EditorAnimalMenu, PICROE, Point16(2, 36), PICTURE_ANIMAL_ROE);
+            WNDAnimal->addPicture(EditorAnimalMenu, PICDUCK, Point16(36, 36), PICTURE_ANIMAL_DUCK);
+            WNDAnimal->addPicture(EditorAnimalMenu, PICSHEEP, Point16(70, 36), PICTURE_ANIMAL_SHEEP);
 
             MapObj = global::s2->getMapObj();
             MapObj->setMode(EDITOR_MODE_ANIMAL);
@@ -1732,11 +1728,11 @@ void callback::EditorPlayerMenu(int Param)
             MapObj->setMode(EDITOR_MODE_FLAG);
             MapObj->setModeContent(PlayerIdx);
 
-            WNDPlayer->addButton(EditorPlayerMenu, PLAYER_REDUCE, 0, 0, 20, 20, BUTTON_GREY, "-");
+            WNDPlayer->addButton(EditorPlayerMenu, PLAYER_REDUCE, Point16(0, 0), Extent16(20, 20), BUTTON_GREY, "-");
             PlayerNumberText =
-              WNDPlayer->addText(std::to_string(PlayerIdx + 1), 26, 4, FontSize::Large, FontColor::Orange);
-            WNDPlayer->addButton(EditorPlayerMenu, PLAYER_RAISE, 40, 0, 20, 20, BUTTON_GREY, "+");
-            WNDPlayer->addButton(EditorPlayerMenu, GOTO_PLAYER, 0, 20, 60, 20, BUTTON_GREY, "Go to");
+              WNDPlayer->addText(std::to_string(PlayerIdx + 1), Point16(26, 4), FontSize::Large, FontColor::Orange);
+            WNDPlayer->addButton(EditorPlayerMenu, PLAYER_RAISE, Point16(40, 0), Extent16(20, 20), BUTTON_GREY, "+");
+            WNDPlayer->addButton(EditorPlayerMenu, GOTO_PLAYER, Point16(0, 20), Extent16(60, 20), BUTTON_GREY, "Go to");
             break;
 
         case PLAYER_REDUCE:
@@ -1746,7 +1742,7 @@ void callback::EditorPlayerMenu(int Param)
                 MapObj->setModeContent(PlayerIdx);
                 WNDPlayer->delText(PlayerNumberText);
                 PlayerNumberText =
-                  WNDPlayer->addText(std::to_string(PlayerIdx + 1), 26, 4, FontSize::Large, FontColor::Orange);
+                  WNDPlayer->addText(std::to_string(PlayerIdx + 1), Point16(26, 4), FontSize::Large, FontColor::Orange);
             }
             break;
 
@@ -1757,7 +1753,7 @@ void callback::EditorPlayerMenu(int Param)
                 MapObj->setModeContent(PlayerIdx);
                 WNDPlayer->delText(PlayerNumberText);
                 PlayerNumberText =
-                  WNDPlayer->addText(std::to_string(PlayerIdx + 1), 26, 4, FontSize::Large, FontColor::Orange);
+                  WNDPlayer->addText(std::to_string(PlayerIdx + 1), Point16(26, 4), FontSize::Large, FontColor::Orange);
             }
             break;
 
@@ -1848,12 +1844,11 @@ void callback::EditorCursorMenu(int Param)
                                         WINDOW_CLOSE | WINDOW_MINIMIZE | WINDOW_MOVE));
             MapObj = global::s2->getMapObj();
 
-            CursorModeButton = WNDCursor->addButton(EditorCursorMenu, CURSORMODE, 2, 2, 96, 32, BUTTON_GREY, "Hexagon");
-            CursorRandomButton = WNDCursor->addButton(EditorCursorMenu, CURSORRANDOM, 2, 34, 196, 32, BUTTON_GREY,
-                                                      "Cursor-Activity: static");
-            WNDCursor->addButton(EditorCursorMenu, TRIANGLE, 2, 66, 32, 32, BUTTON_GREY, nullptr);
-            trianglePictureArrowUp = WNDCursor->addStaticPicture(8, 74, CURSOR_SYMBOL_ARROW_UP);
-            trianglePictureArrowDown = WNDCursor->addStaticPicture(17, 77, CURSOR_SYMBOL_ARROW_DOWN);
+            CursorModeButton = WNDCursor->addButton(EditorCursorMenu, CURSORMODE, Point16(2, 2), Extent16(96, 32), BUTTON_GREY, "Hexagon");
+            CursorRandomButton = WNDCursor->addButton(EditorCursorMenu, CURSORRANDOM, Point16(2, 34), Extent16(196, 32), BUTTON_GREY, "Cursor-Activity: static");
+            WNDCursor->addButton(EditorCursorMenu, TRIANGLE, Point16(2, 66), Extent16(32, 32), BUTTON_GREY, nullptr);
+            trianglePictureArrowUp = WNDCursor->addStaticPicture(Point16(8, 74), CURSOR_SYMBOL_ARROW_UP);
+            trianglePictureArrowDown = WNDCursor->addStaticPicture(Point16(17, 77), CURSOR_SYMBOL_ARROW_DOWN);
             if(MapObj)
             {
                 MapObj->setVertexFillRSU(true);
@@ -1877,7 +1872,7 @@ void callback::EditorCursorMenu(int Param)
                 // add random if necessary
                 if(trianglePictureRandom == -1)
                     trianglePictureRandom =
-                      WNDCursor->addStaticPicture(14, 76, FONT14_SPACE + 31 * 7 + 5); // Interrogation point
+                      WNDCursor->addStaticPicture(Point16(14, 76), FONT14_SPACE + 31 * 7 + 5); // Interrogation point
                 MapObj->setVertexFillRSU(false);
                 MapObj->setVertexFillUSD(false);
                 MapObj->setVertexFillRandom(true);
@@ -1885,10 +1880,10 @@ void callback::EditorCursorMenu(int Param)
             {
                 // only arrow down is shown, so upgrade to both arrows
                 // add arrow up
-                trianglePictureArrowUp = WNDCursor->addStaticPicture(8, 74, CURSOR_SYMBOL_ARROW_UP);
+                trianglePictureArrowUp = WNDCursor->addStaticPicture(Point16(8, 74), CURSOR_SYMBOL_ARROW_UP);
                 // add arrow down if necessary
                 if(trianglePictureArrowDown == -1)
-                    trianglePictureArrowDown = WNDCursor->addStaticPicture(17, 77, CURSOR_SYMBOL_ARROW_DOWN);
+                    trianglePictureArrowDown = WNDCursor->addStaticPicture(Point16(17, 77), CURSOR_SYMBOL_ARROW_DOWN);
                 MapObj->setVertexFillRSU(true);
                 MapObj->setVertexFillUSD(true);
                 MapObj->setVertexFillRandom(false);
@@ -1901,7 +1896,7 @@ void callback::EditorCursorMenu(int Param)
                     WNDCursor->delStaticPicture(trianglePictureArrowUp);
                     trianglePictureArrowUp = -1;
                 }
-                trianglePictureArrowDown = WNDCursor->addStaticPicture(17, 77, CURSOR_SYMBOL_ARROW_DOWN);
+                trianglePictureArrowDown = WNDCursor->addStaticPicture(Point16(17, 77), CURSOR_SYMBOL_ARROW_DOWN);
                 MapObj->setVertexFillRSU(false);
                 MapObj->setVertexFillUSD(true);
                 MapObj->setVertexFillRandom(false);
@@ -1912,7 +1907,7 @@ void callback::EditorCursorMenu(int Param)
                 trianglePictureRandom = -1;
                 // add arrow up if necessary
                 if(trianglePictureArrowUp == -1)
-                    trianglePictureArrowUp = WNDCursor->addStaticPicture(8, 74, CURSOR_SYMBOL_ARROW_UP);
+                    trianglePictureArrowUp = WNDCursor->addStaticPicture(Point16(8, 74), CURSOR_SYMBOL_ARROW_UP);
                 // delete arrow down if necessary
                 if(trianglePictureArrowDown != -1)
                 {
@@ -1934,12 +1929,12 @@ void callback::EditorCursorMenu(int Param)
             if(MapObj->getHexagonMode())
             {
                 CursorModeButton =
-                  WNDCursor->addButton(EditorCursorMenu, CURSORMODE, 2, 2, 96, 32, BUTTON_GREY, "Square");
+                  WNDCursor->addButton(EditorCursorMenu, CURSORMODE, Point16(2, 2), Extent16(96, 32), BUTTON_GREY, "Square");
                 MapObj->setHexagonMode(false);
             } else
             {
                 CursorModeButton =
-                  WNDCursor->addButton(EditorCursorMenu, CURSORMODE, 2, 2, 96, 32, BUTTON_GREY, "Hexagon");
+                  WNDCursor->addButton(EditorCursorMenu, CURSORMODE, Point16(2, 2), Extent16(96, 32), BUTTON_GREY, "Hexagon");
                 MapObj->setHexagonMode(true);
             }
             break;
@@ -1951,13 +1946,11 @@ void callback::EditorCursorMenu(int Param)
             }
             if(MapObj->getVertexActivityRandom())
             {
-                CursorRandomButton = WNDCursor->addButton(EditorCursorMenu, CURSORRANDOM, 2, 34, 196, 32, BUTTON_GREY,
-                                                          "Cursor-Activity: static");
+                CursorRandomButton = WNDCursor->addButton(EditorCursorMenu, CURSORRANDOM, Point16(2, 34), Extent16(196, 32), BUTTON_GREY, "Cursor-Activity: static");
                 MapObj->setVertexActivityRandom(false);
             } else
             {
-                CursorRandomButton = WNDCursor->addButton(EditorCursorMenu, CURSORRANDOM, 2, 34, 196, 32, BUTTON_GREY,
-                                                          "Cursor-Activity: random");
+                CursorRandomButton = WNDCursor->addButton(EditorCursorMenu, CURSORRANDOM, Point16(2, 34), Extent16(196, 32), BUTTON_GREY, "Cursor-Activity: random");
                 MapObj->setVertexActivityRandom(true);
             }
             break;
@@ -2047,45 +2040,43 @@ void callback::EditorCreateMenu(int Param)
                                         WINDOW_GREEN1, WINDOW_CLOSE | WINDOW_MOVE | WINDOW_MINIMIZE));
             MapObj = global::s2->getMapObj();
 
-            WNDCreate->addText("Width", 95, 4, FontSize::Small, FontColor::Yellow);
-            WNDCreate->addButton(EditorCreateMenu, REDUCE_WIDTH_128, 0, 15, 35, 20, BUTTON_GREY, "128<-");
-            WNDCreate->addButton(EditorCreateMenu, REDUCE_WIDTH_16, 35, 15, 35, 20, BUTTON_GREY, "16<-");
-            WNDCreate->addButton(EditorCreateMenu, REDUCE_WIDTH_2, 70, 15, 25, 20, BUTTON_GREY, "2<-");
-            TextWidth = WNDCreate->addText(std::to_string(width), 105, 17, FontSize::Large, FontColor::Yellow);
-            WNDCreate->addButton(EditorCreateMenu, RAISE_WIDTH_2, 143, 15, 25, 20, BUTTON_GREY, "->2");
-            WNDCreate->addButton(EditorCreateMenu, RAISE_WIDTH_16, 168, 15, 35, 20, BUTTON_GREY, "->16");
-            WNDCreate->addButton(EditorCreateMenu, RAISE_WIDTH_128, 203, 15, 35, 20, BUTTON_GREY, "->128");
+            WNDCreate->addText("Width", Point16(95, 4), FontSize::Small, FontColor::Yellow);
+            WNDCreate->addButton(EditorCreateMenu, REDUCE_WIDTH_128, Point16(0, 15), Extent16(35, 20), BUTTON_GREY, "128<-");
+            WNDCreate->addButton(EditorCreateMenu, REDUCE_WIDTH_16, Point16(35, 15), Extent16(35, 20), BUTTON_GREY, "16<-");
+            WNDCreate->addButton(EditorCreateMenu, REDUCE_WIDTH_2, Point16(70, 15), Extent16(25, 20), BUTTON_GREY, "2<-");
+            TextWidth = WNDCreate->addText(std::to_string(width), Point16(105, 17), FontSize::Large, FontColor::Yellow);
+            WNDCreate->addButton(EditorCreateMenu, RAISE_WIDTH_2, Point16(143, 15), Extent16(25, 20), BUTTON_GREY, "->2");
+            WNDCreate->addButton(EditorCreateMenu, RAISE_WIDTH_16, Point16(168, 15), Extent16(35, 20), BUTTON_GREY, "->16");
+            WNDCreate->addButton(EditorCreateMenu, RAISE_WIDTH_128, Point16(203, 15), Extent16(35, 20), BUTTON_GREY, "->128");
 
-            WNDCreate->addText("Height", 100, 40, FontSize::Small, FontColor::Yellow);
-            WNDCreate->addButton(EditorCreateMenu, REDUCE_HEIGHT_128, 0, 49, 35, 20, BUTTON_GREY, "128<-");
-            WNDCreate->addButton(EditorCreateMenu, REDUCE_HEIGHT_16, 35, 49, 35, 20, BUTTON_GREY, "16<-");
-            WNDCreate->addButton(EditorCreateMenu, REDUCE_HEIGHT_2, 70, 49, 25, 20, BUTTON_GREY, "2<-");
-            TextHeight = WNDCreate->addText(std::to_string(height), 105, 51, FontSize::Large, FontColor::Yellow);
-            WNDCreate->addButton(EditorCreateMenu, RAISE_HEIGHT_2, 143, 49, 25, 20, BUTTON_GREY, "->2");
-            WNDCreate->addButton(EditorCreateMenu, RAISE_HEIGHT_16, 168, 49, 35, 20, BUTTON_GREY, "->16");
-            WNDCreate->addButton(EditorCreateMenu, RAISE_HEIGHT_128, 203, 49, 35, 20, BUTTON_GREY, "->128");
+            WNDCreate->addText("Height", Point16(100, 40), FontSize::Small, FontColor::Yellow);
+            WNDCreate->addButton(EditorCreateMenu, REDUCE_HEIGHT_128, Point16(0, 49), Extent16(35, 20), BUTTON_GREY, "128<-");
+            WNDCreate->addButton(EditorCreateMenu, REDUCE_HEIGHT_16, Point16(35, 49), Extent16(35, 20), BUTTON_GREY, "16<-");
+            WNDCreate->addButton(EditorCreateMenu, REDUCE_HEIGHT_2, Point16(70, 49), Extent16(25, 20), BUTTON_GREY, "2<-");
+            TextHeight = WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
+            WNDCreate->addButton(EditorCreateMenu, RAISE_HEIGHT_2, Point16(143, 49), Extent16(25, 20), BUTTON_GREY, "->2");
+            WNDCreate->addButton(EditorCreateMenu, RAISE_HEIGHT_16, Point16(168, 49), Extent16(35, 20), BUTTON_GREY, "->16");
+            WNDCreate->addButton(EditorCreateMenu, RAISE_HEIGHT_128, Point16(203, 49), Extent16(35, 20), BUTTON_GREY, "->128");
 
-            WNDCreate->addText("Landscape", 85, 80, FontSize::Small, FontColor::Yellow);
-            ButtonLandscape = WNDCreate->addButton(
-              EditorCreateMenu, CHANGE_LANDSCAPE, 64, 93, 110, 20, BUTTON_GREY,
-              (LandscapeType == 0 ? "Greenland" : (LandscapeType == 1 ? "Wasteland" : "Winterworld")));
+            WNDCreate->addText("Landscape", Point16(85, 80), FontSize::Small, FontColor::Yellow);
+            ButtonLandscape = WNDCreate->addButton(EditorCreateMenu, CHANGE_LANDSCAPE, Point16(64, 93), Extent16(110, 20), BUTTON_GREY, (LandscapeType == 0 ? "Greenland" : (LandscapeType == 1 ? "Wasteland" : "Winterworld")));
 
-            WNDCreate->addText("Main area", 82, 120, FontSize::Small, FontColor::Yellow);
-            WNDCreate->addButton(EditorCreateMenu, TEXTURE_PREVIOUS, 45, 139, 35, 20, BUTTON_GREY, "-");
-            PicTextureIndex = WNDCreate->addStaticPicture(102, 133, PicTextureIndexGlobal);
-            WNDCreate->addButton(EditorCreateMenu, TEXTURE_NEXT, 158, 139, 35, 20, BUTTON_GREY, "+");
+            WNDCreate->addText("Main area", Point16(82, 120), FontSize::Small, FontColor::Yellow);
+            WNDCreate->addButton(EditorCreateMenu, TEXTURE_PREVIOUS, Point16(45, 139), Extent16(35, 20), BUTTON_GREY, "-");
+            PicTextureIndex = WNDCreate->addStaticPicture(Point16(102, 133), PicTextureIndexGlobal);
+            WNDCreate->addButton(EditorCreateMenu, TEXTURE_NEXT, Point16(158, 139), Extent16(35, 20), BUTTON_GREY, "+");
 
-            WNDCreate->addText("Border size", 103, 175, FontSize::Small, FontColor::Yellow);
-            WNDCreate->addButton(EditorCreateMenu, REDUCE_BORDER, 45, 186, 35, 20, BUTTON_GREY, "-");
-            TextBorder = WNDCreate->addText(std::to_string(border), 112, 188, FontSize::Large, FontColor::Yellow);
-            WNDCreate->addButton(EditorCreateMenu, RAISE_BORDER, 158, 186, 35, 20, BUTTON_GREY, "+");
+            WNDCreate->addText("Border size", Point16(103, 175), FontSize::Small, FontColor::Yellow);
+            WNDCreate->addButton(EditorCreateMenu, REDUCE_BORDER, Point16(45, 186), Extent16(35, 20), BUTTON_GREY, "-");
+            TextBorder = WNDCreate->addText(std::to_string(border), Point16(112, 188), FontSize::Large, FontColor::Yellow);
+            WNDCreate->addButton(EditorCreateMenu, RAISE_BORDER, Point16(158, 186), Extent16(35, 20), BUTTON_GREY, "+");
 
-            WNDCreate->addText("Border area", 65, 215, FontSize::Small, FontColor::Yellow);
-            WNDCreate->addButton(EditorCreateMenu, BORDER_TEXTURE_PREVIOUS, 45, 234, 35, 20, BUTTON_GREY, "-");
-            PicBorderTextureIndex = WNDCreate->addStaticPicture(102, 228, PicBorderTextureIndexGlobal);
-            WNDCreate->addButton(EditorCreateMenu, BORDER_TEXTURE_NEXT, 158, 234, 35, 20, BUTTON_GREY, "+");
+            WNDCreate->addText("Border area", Point16(65, 215), FontSize::Small, FontColor::Yellow);
+            WNDCreate->addButton(EditorCreateMenu, BORDER_TEXTURE_PREVIOUS, Point16(45, 234), Extent16(35, 20), BUTTON_GREY, "-");
+            PicBorderTextureIndex = WNDCreate->addStaticPicture(Point16(102, 228), PicBorderTextureIndexGlobal);
+            WNDCreate->addButton(EditorCreateMenu, BORDER_TEXTURE_NEXT, Point16(158, 234), Extent16(35, 20), BUTTON_GREY, "+");
 
-            WNDCreate->addButton(EditorCreateMenu, CREATE_WORLD, 44, 275, 150, 40, BUTTON_GREY, "Create world");
+            WNDCreate->addButton(EditorCreateMenu, CREATE_WORLD, Point16(44, 275), Extent16(150, 40), BUTTON_GREY, "Create world");
             break;
 
         case CALL_FROM_GAMELOOP: break;
@@ -2096,7 +2087,7 @@ void callback::EditorCreateMenu(int Param)
             else
                 width = 32;
             WNDCreate->delText(TextWidth);
-            TextWidth = WNDCreate->addText(std::to_string(width), 105, 17, FontSize::Large, FontColor::Yellow);
+            TextWidth = WNDCreate->addText(std::to_string(width), Point16(105, 17), FontSize::Large, FontColor::Yellow);
             break;
         case REDUCE_WIDTH_16:
             if(width - 16 >= 32)
@@ -2104,7 +2095,7 @@ void callback::EditorCreateMenu(int Param)
             else
                 width = 32;
             WNDCreate->delText(TextWidth);
-            TextWidth = WNDCreate->addText(std::to_string(width), 105, 17, FontSize::Large, FontColor::Yellow);
+            TextWidth = WNDCreate->addText(std::to_string(width), Point16(105, 17), FontSize::Large, FontColor::Yellow);
             break;
         case REDUCE_WIDTH_2:
             if(width - 2 >= 32)
@@ -2112,7 +2103,7 @@ void callback::EditorCreateMenu(int Param)
             else
                 width = 32;
             WNDCreate->delText(TextWidth);
-            TextWidth = WNDCreate->addText(std::to_string(width), 105, 17, FontSize::Large, FontColor::Yellow);
+            TextWidth = WNDCreate->addText(std::to_string(width), Point16(105, 17), FontSize::Large, FontColor::Yellow);
             break;
         case RAISE_WIDTH_2:
             if(width + 2 <= MAXMAPWIDTH)
@@ -2120,7 +2111,7 @@ void callback::EditorCreateMenu(int Param)
             else
                 width = MAXMAPWIDTH;
             WNDCreate->delText(TextWidth);
-            TextWidth = WNDCreate->addText(std::to_string(width), 105, 17, FontSize::Large, FontColor::Yellow);
+            TextWidth = WNDCreate->addText(std::to_string(width), Point16(105, 17), FontSize::Large, FontColor::Yellow);
             break;
         case RAISE_WIDTH_16:
             if(width + 16 <= MAXMAPWIDTH)
@@ -2128,7 +2119,7 @@ void callback::EditorCreateMenu(int Param)
             else
                 width = MAXMAPWIDTH;
             WNDCreate->delText(TextWidth);
-            TextWidth = WNDCreate->addText(std::to_string(width), 105, 17, FontSize::Large, FontColor::Yellow);
+            TextWidth = WNDCreate->addText(std::to_string(width), Point16(105, 17), FontSize::Large, FontColor::Yellow);
             break;
         case RAISE_WIDTH_128:
             if(width + 128 <= MAXMAPWIDTH)
@@ -2136,7 +2127,7 @@ void callback::EditorCreateMenu(int Param)
             else
                 width = MAXMAPWIDTH;
             WNDCreate->delText(TextWidth);
-            TextWidth = WNDCreate->addText(std::to_string(width), 105, 17, FontSize::Large, FontColor::Yellow);
+            TextWidth = WNDCreate->addText(std::to_string(width), Point16(105, 17), FontSize::Large, FontColor::Yellow);
             break;
         case REDUCE_HEIGHT_128:
             if(height - 128 >= 32)
@@ -2144,7 +2135,7 @@ void callback::EditorCreateMenu(int Param)
             else
                 height = 32;
             WNDCreate->delText(TextHeight);
-            TextHeight = WNDCreate->addText(std::to_string(height), 105, 51, FontSize::Large, FontColor::Yellow);
+            TextHeight = WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
             break;
         case REDUCE_HEIGHT_16:
             if(height - 16 >= 32)
@@ -2152,7 +2143,7 @@ void callback::EditorCreateMenu(int Param)
             else
                 height = 32;
             WNDCreate->delText(TextHeight);
-            TextHeight = WNDCreate->addText(std::to_string(height), 105, 51, FontSize::Large, FontColor::Yellow);
+            TextHeight = WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
             break;
         case REDUCE_HEIGHT_2:
             if(height - 2 >= 32)
@@ -2160,7 +2151,7 @@ void callback::EditorCreateMenu(int Param)
             else
                 height = 32;
             WNDCreate->delText(TextHeight);
-            TextHeight = WNDCreate->addText(std::to_string(height), 105, 51, FontSize::Large, FontColor::Yellow);
+            TextHeight = WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
             break;
         case RAISE_HEIGHT_2:
             if(height + 2 <= MAXMAPHEIGHT)
@@ -2168,7 +2159,7 @@ void callback::EditorCreateMenu(int Param)
             else
                 height = MAXMAPHEIGHT;
             WNDCreate->delText(TextHeight);
-            TextHeight = WNDCreate->addText(std::to_string(height), 105, 51, FontSize::Large, FontColor::Yellow);
+            TextHeight = WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
             break;
         case RAISE_HEIGHT_16:
             if(height + 16 <= MAXMAPHEIGHT)
@@ -2176,7 +2167,7 @@ void callback::EditorCreateMenu(int Param)
             else
                 height = MAXMAPHEIGHT;
             WNDCreate->delText(TextHeight);
-            TextHeight = WNDCreate->addText(std::to_string(height), 105, 51, FontSize::Large, FontColor::Yellow);
+            TextHeight = WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
             break;
         case RAISE_HEIGHT_128:
             if(height + 128 <= MAXMAPHEIGHT)
@@ -2184,7 +2175,7 @@ void callback::EditorCreateMenu(int Param)
             else
                 height = MAXMAPHEIGHT;
             WNDCreate->delText(TextHeight);
-            TextHeight = WNDCreate->addText(std::to_string(height), 105, 51, FontSize::Large, FontColor::Yellow);
+            TextHeight = WNDCreate->addText(std::to_string(height), Point16(105, 51), FontSize::Large, FontColor::Yellow);
             break;
 
         case CHANGE_LANDSCAPE:
@@ -2192,9 +2183,7 @@ void callback::EditorCreateMenu(int Param)
             if(LandscapeType > 2)
                 LandscapeType = 0;
             WNDCreate->delButton(ButtonLandscape);
-            ButtonLandscape = WNDCreate->addButton(
-              EditorCreateMenu, CHANGE_LANDSCAPE, 64, 93, 110, 20, BUTTON_GREY,
-              (LandscapeType == 0 ? "Greenland" : (LandscapeType == 1 ? "Wasteland" : "Winterworld")));
+            ButtonLandscape = WNDCreate->addButton(EditorCreateMenu, CHANGE_LANDSCAPE, Point16(64, 93), Extent16(110, 20), BUTTON_GREY, (LandscapeType == 0 ? "Greenland" : (LandscapeType == 1 ? "Wasteland" : "Winterworld")));
             switch(LandscapeType)
             {
                 case 0:
@@ -2213,8 +2202,8 @@ void callback::EditorCreateMenu(int Param)
             }
             WNDCreate->delStaticPicture(PicTextureIndex);
             WNDCreate->delStaticPicture(PicBorderTextureIndex);
-            PicTextureIndex = WNDCreate->addStaticPicture(102, 133, PicTextureIndexGlobal);
-            PicBorderTextureIndex = WNDCreate->addStaticPicture(102, 228, PicBorderTextureIndexGlobal);
+            PicTextureIndex = WNDCreate->addStaticPicture(Point16(102, 133), PicTextureIndexGlobal);
+            PicBorderTextureIndex = WNDCreate->addStaticPicture(Point16(102, 228), PicBorderTextureIndexGlobal);
             break;
 
         case TEXTURE_PREVIOUS:
@@ -2317,7 +2306,7 @@ void callback::EditorCreateMenu(int Param)
                 texture = TRIANGLE_TEXTURE_LAVA;
             }
             WNDCreate->delStaticPicture(PicTextureIndex);
-            PicTextureIndex = WNDCreate->addStaticPicture(102, 133, PicTextureIndexGlobal);
+            PicTextureIndex = WNDCreate->addStaticPicture(Point16(102, 133), PicTextureIndexGlobal);
             break;
         case TEXTURE_NEXT:
             PicTextureIndexGlobal++;
@@ -2419,18 +2408,18 @@ void callback::EditorCreateMenu(int Param)
                 texture = TRIANGLE_TEXTURE_LAVA;
             }
             WNDCreate->delStaticPicture(PicTextureIndex);
-            PicTextureIndex = WNDCreate->addStaticPicture(102, 133, PicTextureIndexGlobal);
+            PicTextureIndex = WNDCreate->addStaticPicture(Point16(102, 133), PicTextureIndexGlobal);
             break;
 
         case REDUCE_BORDER:
             border = std::max(0, border - 1);
             WNDCreate->delText(TextBorder);
-            TextBorder = WNDCreate->addText(std::to_string(border), 112, 188, FontSize::Large, FontColor::Yellow);
+            TextBorder = WNDCreate->addText(std::to_string(border), Point16(112, 188), FontSize::Large, FontColor::Yellow);
             break;
         case RAISE_BORDER:
             border = std::min(12, border + 1);
             WNDCreate->delText(TextBorder);
-            TextBorder = WNDCreate->addText(std::to_string(border), 112, 188, FontSize::Large, FontColor::Yellow);
+            TextBorder = WNDCreate->addText(std::to_string(border), Point16(112, 188), FontSize::Large, FontColor::Yellow);
             break;
 
         case BORDER_TEXTURE_PREVIOUS:
@@ -2533,7 +2522,7 @@ void callback::EditorCreateMenu(int Param)
                 border_texture = TRIANGLE_TEXTURE_LAVA;
             }
             WNDCreate->delStaticPicture(PicBorderTextureIndex);
-            PicBorderTextureIndex = WNDCreate->addStaticPicture(102, 228, PicBorderTextureIndexGlobal);
+            PicBorderTextureIndex = WNDCreate->addStaticPicture(Point16(102, 228), PicBorderTextureIndexGlobal);
             break;
         case BORDER_TEXTURE_NEXT:
             PicBorderTextureIndexGlobal++;
@@ -2635,7 +2624,7 @@ void callback::EditorCreateMenu(int Param)
                 border_texture = TRIANGLE_TEXTURE_LAVA;
             }
             WNDCreate->delStaticPicture(PicBorderTextureIndex);
-            PicBorderTextureIndex = WNDCreate->addStaticPicture(102, 228, PicBorderTextureIndexGlobal);
+            PicBorderTextureIndex = WNDCreate->addStaticPicture(Point16(102, 228), PicBorderTextureIndexGlobal);
             break;
 
         case CREATE_WORLD:
@@ -2845,18 +2834,18 @@ void callback::viewer(int Param)
               std::make_unique<CWindow>(viewer, WINDOWQUIT, Position(0, 0), Extent(250, 140), "Viewer", WINDOW_GREEN1,
                                         WINDOW_CLOSE | WINDOW_MOVE | WINDOW_RESIZE | WINDOW_MINIMIZE));
             global::s2->RegisterCallback(viewer);
-            WNDViewer->addButton(viewer, BACKWARD_100, 0, 0, 35, 20, BUTTON_GREY, "100<-");
-            WNDViewer->addButton(viewer, BACKWARD_10, 35, 0, 35, 20, BUTTON_GREY, "10<-");
-            WNDViewer->addButton(viewer, BACKWARD_1, 70, 0, 35, 20, BUTTON_GREY, "1<-");
-            WNDViewer->addButton(viewer, FORWARD_1, 105, 0, 35, 20, BUTTON_GREY, "->1");
-            WNDViewer->addButton(viewer, FORWARD_10, 140, 0, 35, 20, BUTTON_GREY, "->10");
-            WNDViewer->addButton(viewer, FORWARD_100, 175, 0, 35, 20, BUTTON_GREY, "->100");
+            WNDViewer->addButton(viewer, BACKWARD_100, Point16(0, 0), Extent16(35, 20), BUTTON_GREY, "100<-");
+            WNDViewer->addButton(viewer, BACKWARD_10, Point16(35, 0), Extent16(35, 20), BUTTON_GREY, "10<-");
+            WNDViewer->addButton(viewer, BACKWARD_1, Point16(70, 0), Extent16(35, 20), BUTTON_GREY, "1<-");
+            WNDViewer->addButton(viewer, FORWARD_1, Point16(105, 0), Extent16(35, 20), BUTTON_GREY, "->1");
+            WNDViewer->addButton(viewer, FORWARD_10, Point16(140, 0), Extent16(35, 20), BUTTON_GREY, "->10");
+            WNDViewer->addButton(viewer, FORWARD_100, Point16(175, 0), Extent16(35, 20), BUTTON_GREY, "->100");
             break;
 
         case CALL_FROM_GAMELOOP:
             if(PicInWndIndex >= 0)
                 WNDViewer->delStaticPicture(PicInWndIndex);
-            PicInWndIndex = WNDViewer->addStaticPicture(5, 30, index);
+            PicInWndIndex = WNDViewer->addStaticPicture(Point16(5, 30), index);
 
             if(PicInfosText)
             {
@@ -2868,7 +2857,7 @@ void callback::viewer(int Param)
                 const auto infos =
                   helpers::format("index=%d, w=%d, h=%d, nx=%d, ny=%d", index, global::bmpArray[index].w,
                                   global::bmpArray[index].h, global::bmpArray[index].nx, global::bmpArray[index].ny);
-                PicInfosText = WNDViewer->addText(infos, 220, 3, FontSize::Large, FontColor::Red);
+                PicInfosText = WNDViewer->addText(infos, Point16(220, 3), FontSize::Large, FontColor::Red);
             }
 
             break;
@@ -2975,19 +2964,17 @@ void callback::submenu1(int Param)
     {
         case INITIALIZING_CALL:
             SubMenu = global::s2->RegisterMenu(std::make_unique<CMenu>(SPLASHSCREEN_SUBMENU1));
-            SubMenu->addButton(submenu1, MAINMENU, 400, 440, 200, 20, BUTTON_RED1, "back");
-            greatMoon = SubMenu->addButton(submenu1, GREATMOON, 100, 100, 200, 200, BUTTON_STONE, nullptr, MOON);
+            SubMenu->addButton(submenu1, MAINMENU, Point16(400, 440), Extent16(200, 20), BUTTON_RED1, "back");
+            greatMoon = SubMenu->addButton(submenu1, GREATMOON, Point16(100, 100), Extent16(200, 200), BUTTON_STONE, nullptr, MOON);
             greatMoon->setMotionParams(GREATMOONENTRY, GREATMOONLEAVE);
-            SubMenu->addButton(submenu1, SMALLMOON, 100, 350, global::bmpArray[MOON].w, global::bmpArray[MOON].h,
-                               BUTTON_STONE, nullptr, MOON);
-            SubMenu->addButton(submenu1, TOOSMALL, 100, 400, global::bmpArray[MOON].w - 1, global::bmpArray[MOON].h - 1,
-                               BUTTON_STONE, nullptr, MOON);
-            SubMenu->addButton(submenu1, CREATEWINDOW, 500, 10, 130, 30, BUTTON_GREEN1, "Create window");
-            picObject = SubMenu->addPicture(submenu1, PICOBJECT, 200, 30, MIS0BOBS_SHIP);
+            SubMenu->addButton(submenu1, SMALLMOON, Point16(100, 350), Extent16(global::bmpArray[MOON].w, global::bmpArray[MOON].h), BUTTON_STONE, nullptr, MOON);
+            SubMenu->addButton(submenu1, TOOSMALL, Point16(100, 400), Extent16(global::bmpArray[MOON].w - 1, global::bmpArray[MOON].h - 1), BUTTON_STONE, nullptr, MOON);
+            SubMenu->addButton(submenu1, CREATEWINDOW, Point16(500, 10), Extent16(130, 30), BUTTON_GREEN1, "Create window");
+            picObject = SubMenu->addPicture(submenu1, PICOBJECT, Point16(200, 30), MIS0BOBS_SHIP);
             picObject->setMotionParams(PICOBJECTENTRY, PICOBJECTLEAVE);
             // text block with \n
-            SubMenu->addText("\nTextblock:\n\nNeue Zeile\nNoch eine neue Zeile", 400, 200, FontSize::Large);
-            testTextfield = SubMenu->addTextfield(400, 300, 10, 3);
+            SubMenu->addText("\nTextblock:\n\nNeue Zeile\nNoch eine neue Zeile", Point16(400, 200), FontSize::Large);
+            testTextfield = SubMenu->addTextfield(Point16(400, 300), 10, 3);
             testSelectBox = SubMenu->addSelectBox(Point16(500, 500), Extent16(300, 200));
             testSelectBox->addOption("Erste Option", submenu1, SELECTBOX_OPTION1);
             testSelectBox->addOption("Zweite Option", submenu1, SELECTBOX_OPTION2);
@@ -3022,10 +3009,8 @@ void callback::submenu1(int Param)
             break;
 
         case GREATMOON:
-            SubMenu->addText("Title!", 300, 10, FontSize::Large);
-            SubMenu->addText(
-              helpers::format("Window X: %d Window Y: %d", global::s2->GameResolution.x, global::s2->GameResolution.y),
-              10, 10, FontSize::Large);
+            SubMenu->addText("Title!", Point16(300, 10), FontSize::Large);
+            SubMenu->addText(helpers::format("Window X: %d Window Y: %d", global::s2->GameResolution.x, global::s2->GameResolution.y), Point16(10, 10), FontSize::Large);
             break;
 
         case SMALLMOON:
@@ -3036,7 +3021,7 @@ void callback::submenu1(int Param)
 
         case TOOSMALL:
             if(picIndex == -1)
-                picIndex = SubMenu->addStaticPicture(0, 0, MAINFRAME_640_480);
+                picIndex = SubMenu->addStaticPicture(Point16(0, 0), MAINFRAME_640_480);
             break;
 
         case CREATEWINDOW:
@@ -3045,12 +3030,12 @@ void callback::submenu1(int Param)
                 testWindow = global::s2->RegisterWindow(std::make_unique<CWindow>(
                   submenu1, TESTWINDOWQUITMESSAGE, Position(5, 5), Extent(350, 240), "Window", WINDOW_GREEN1,
                   WINDOW_CLOSE | WINDOW_MOVE | WINDOW_MINIMIZE | WINDOW_RESIZE));
-                testWindow->addText("Text inside the window", 10, 10, FontSize::Large);
-                testWindow->addButton(submenu1, -10, 150, 100, 210, 30, BUTTON_GREEN2, "Button inside the window");
-                testWindowPicture = testWindow->addPicture(submenu1, TESTWINDOWPICTURE, 10, 60, MIS2BOBS_FORTRESS);
+                testWindow->addText("Text inside the window", Point16(10, 10), FontSize::Large);
+                testWindow->addButton(submenu1, -10, Point16(150, 100), Extent16(210, 30), BUTTON_GREEN2, "Button inside the window");
+                testWindowPicture = testWindow->addPicture(submenu1, TESTWINDOWPICTURE, Point16(10, 60), MIS2BOBS_FORTRESS);
                 testWindowPicture->setMotionParams(TESTWINDOWPICTUREENTRY, TESTWINDOWPICTURELEAVE);
                 testTextfield_testWindow =
-                  testWindow->addTextfield(130, 30, 10, 3, FontSize::Large, FontColor::Red, BUTTON_GREY, true);
+                  testWindow->addTextfield(Point16(130, 30), 10, 3, FontSize::Large, FontColor::Red, BUTTON_GREY, true);
                 testTextfield_testWindow->setText(
                   "This is a very long test text in order to destroy the text field completely once and for all");
             }
@@ -3059,14 +3044,14 @@ void callback::submenu1(int Param)
                 testWindow2 = global::s2->RegisterWindow(std::make_unique<CWindow>(
                   submenu1, TESTWINDOW2QUITMESSAGE, Position(200, 5), Extent(350, 240), "Another Window", WINDOW_GREEN1,
                   WINDOW_CLOSE | WINDOW_MOVE | WINDOW_MINIMIZE | WINDOW_RESIZE));
-                testWindow2->addText("Text inside the window", 50, 40, FontSize::Small);
-                testWindow2->addButton(submenu1, -10, 100, 100, 100, 20, BUTTON_GREEN2, "Button");
+                testWindow2->addText("Text inside the window", Point16(50, 40), FontSize::Small);
+                testWindow2->addButton(submenu1, -10, Point16(100, 100), Extent16(100, 20), BUTTON_GREEN2, "Button");
             }
             break;
 
         case GREATMOONENTRY:
             if(!greatMoonText)
-                greatMoonText = SubMenu->addText("Test-Text", 100, 10, FontSize::Large);
+                greatMoonText = SubMenu->addText("Test-Text", Point16(100, 10), FontSize::Large);
             break;
 
         case GREATMOONLEAVE:
@@ -3087,7 +3072,7 @@ void callback::submenu1(int Param)
 
         case PICOBJECTENTRY:
             if(!greatMoonText)
-                greatMoonText = SubMenu->addText("Test-Text", 100, 10, FontSize::Large);
+                greatMoonText = SubMenu->addText("Test-Text", Point16(100, 10), FontSize::Large);
             break;
 
         case PICOBJECTLEAVE:
@@ -3101,7 +3086,7 @@ void callback::submenu1(int Param)
         case TESTWINDOWPICTURE:
             assert(testWindow);
             if(!testWindowText)
-                testWindowText = testWindow->addText("Clicked on castle", 10, 200, FontSize::Medium);
+                testWindowText = testWindow->addText("Clicked on castle", Point16(10, 200), FontSize::Medium);
             else
             {
                 testWindow->delText(testWindowText);
@@ -3116,7 +3101,7 @@ void callback::submenu1(int Param)
                 testWindow->delText(testWindowText2);
                 testWindowText2 = nullptr;
             }
-            testWindowText2 = testWindow->addText("Bildbereich betreten", 10, 220, FontSize::Medium);
+            testWindowText2 = testWindow->addText("Bildbereich betreten", Point16(10, 220), FontSize::Medium);
             break;
 
         case TESTWINDOWPICTURELEAVE:
@@ -3126,7 +3111,7 @@ void callback::submenu1(int Param)
                 testWindow->delText(testWindowText2);
                 testWindowText2 = nullptr;
             }
-            testWindowText2 = testWindow->addText("Bildbereich verlassen", 10, 220, FontSize::Medium);
+            testWindowText2 = testWindow->addText("Bildbereich verlassen", Point16(10, 220), FontSize::Medium);
             break;
 
         case TESTWINDOWQUITMESSAGE:
@@ -3151,7 +3136,7 @@ void callback::submenu1(int Param)
                 }
                 if(!counterText)
                 {
-                    counterText = SubMenu->addText(helpers::format("counter: %d", counter), 100, 20, FontSize::Small);
+                    counterText = SubMenu->addText(helpers::format("counter: %d", counter), Point16(100, 20), FontSize::Small);
                 }
 
                 if(TextFrom_testTextfield)
@@ -3159,8 +3144,7 @@ void callback::submenu1(int Param)
                     SubMenu->delText(TextFrom_testTextfield);
                     TextFrom_testTextfield = nullptr;
                 }
-                TextFrom_testTextfield = SubMenu->addText("Der Text im Textfeld lautet: " + testTextfield->getText(),
-                                                          200, 400, FontSize::Large);
+                TextFrom_testTextfield = SubMenu->addText("Der Text im Textfeld lautet: " + testTextfield->getText(), Point16(200, 400), FontSize::Large);
             }
             counter++;
             break;

--- a/include/SdlSurface.h
+++ b/include/SdlSurface.h
@@ -31,13 +31,14 @@ using SdlWindow = std::unique_ptr<SDL_Window, SDLWindowDestroyer>;
 using SdlSurface = std::unique_ptr<SDL_Surface, SdlSurfaceDeleter>;
 using SdlTexture = std::unique_ptr<SDL_Texture, SdlTextureDeleter>;
 
-inline SdlSurface makeRGBSurface(int width, int height, bool withAlpha = false)
+inline SdlSurface makeRGBSurface(unsigned width, unsigned height, bool withAlpha = false)
 {
-    return SdlSurface(SDL_CreateRGBSurface(0, width, height, 32, 0xFF0000, 0xFF00, 0xFF, withAlpha ? 0xFF000000 : 0));
+    return SdlSurface(SDL_CreateRGBSurface(0, static_cast<int>(width), static_cast<int>(height), 32, 0xFF0000, 0xFF00,
+                                           0xFF, withAlpha ? 0xFF000000 : 0));
 }
-inline SdlSurface makePalSurface(int width, int height, const std::array<SDL_Color, 256>& palette)
+inline SdlSurface makePalSurface(unsigned width, unsigned height, const std::array<SDL_Color, 256>& palette)
 {
-    auto surf = SdlSurface(SDL_CreateRGBSurface(0, width, height, 8, 0, 0, 0, 0));
+    auto surf = SdlSurface(SDL_CreateRGBSurface(0, static_cast<int>(width), static_cast<int>(height), 8, 0, 0, 0, 0));
     if(surf)
         SDL_SetPaletteColors(surf->format->palette, palette.data(), 0, palette.size());
     return surf;


### PR DESCRIPTION
Based on this comment https://github.com/Return-To-The-Roots/s25edit/pull/37#pullrequestreview-4507902721

Replace raw x,y and w,h parameters with Position and Extent types across
CMap, CSurface, CControlContainer, CButton, CPicture, CTextfield, and
CFont to make X/Y vs W/H semantics explicit and prevent copy-paste errors.

- CMap/CSurface: vertex/modification methods take `Position pos` instead
  of separate `int x, int y` / `int VertexX, VertexY` / `Uint16 MouseX, MouseY`
- CControlContainer: addButton/addText/addPicture/addStaticPicture/addTextfield
  take `Point16 pos` / `Extent16 size` (consistent with addSelectBox)
- CButton/CPicture/CTextfield/CFont: constructors take `Point16 pos` /
  `Extent16 size` with internal storage renamed to `pos_`/`size_`
- All call sites in callbacks.cpp and CDebug.cpp updated