### PR TITLE
Replace SGE for backgrounds and right menubar

### DIFF
--- a/CGame_Init.cpp
+++ b/CGame_Init.cpp
@@ -9,8 +9,6 @@
 #include "CIO/CWindow.h"
 #include "CMap.h"
 #include "CSurface.h"
-#include "SGE/sge_blib.h"
-#include "SGE/sge_surface.h"
 #include "callbacks.h"
 #include "globals.h"
 #include "lua/GameDataLoader.h"
@@ -69,7 +67,6 @@ bool CGame::Init()
         std::cout << "failure";
         return false;
     }
-    sge_Lock_OFF();
     CFile::init();
 
     /*NOTE: its important to load a palette at first,
@@ -99,11 +96,7 @@ bool CGame::Init()
 
     // std::cout << "\nShow loading screen...";
     showLoadScreen = true;
-    // CSurface::Draw(Surf_Display, global::bmpArray[SPLASHSCREEN_LOADING_S2SCREEN].surface, 0, 0);
-    auto& surfSplash = global::bmpArray[SPLASHSCREEN_LOADING_S2SCREEN].surface;
-    sge_TexturedRect(Surf_Display.get(), 0, 0, Surf_Display->w - 1, 0, 0, Surf_Display->h - 1, Surf_Display->w - 1,
-                     Surf_Display->h - 1, surfSplash.get(), 0, 0, surfSplash->w - 1, 0, 0, surfSplash->h - 1,
-                     surfSplash->w - 1, surfSplash->h - 1);
+    CSurface::DrawStretched(Surf_Display, global::bmpArray[SPLASHSCREEN_LOADING_S2SCREEN].surface);
     RenderPresent();
 
     GameDataLoader gdLoader(global::worldDesc);

--- a/CGame_Render.cpp
+++ b/CGame_Render.cpp
@@ -9,7 +9,6 @@
 #include "CIO/CWindow.h"
 #include "CMap.h"
 #include "CSurface.h"
-#include "SGE/sge_blib.h"
 #include "globals.h"
 #ifdef _WIN32
 #    include "s25editResource.h"
@@ -49,11 +48,7 @@ void CGame::Render()
     // if the S2 loading screen is shown, render only this until user clicks a mouse button
     if(showLoadScreen)
     {
-        // CSurface::Draw(Surf_Display, global::bmpArray[SPLASHSCREEN_LOADING_S2SCREEN].surface, 0, 0);
-        auto& surfLoadScreen = global::bmpArray[SPLASHSCREEN_LOADING_S2SCREEN].surface;
-        sge_TexturedRect(Surf_Display.get(), 0, 0, Surf_Display->w - 1, 0, 0, Surf_Display->h - 1, Surf_Display->w - 1,
-                         Surf_Display->h - 1, surfLoadScreen.get(), 0, 0, surfLoadScreen->w - 1, 0, 0,
-                         surfLoadScreen->h - 1, surfLoadScreen->w - 1, surfLoadScreen->h - 1);
+        CSurface::DrawStretched(Surf_Display, global::bmpArray[SPLASHSCREEN_LOADING_S2SCREEN].surface);
         RenderPresent();
         return;
     }

--- a/CIO/CMenu.cpp
+++ b/CIO/CMenu.cpp
@@ -5,8 +5,8 @@
 
 #include "CMenu.h"
 #include "../CGame.h"
+#include "../CSurface.h"
 #include "../globals.h"
-#include <SGE/sge_blib.h>
 
 CMenu::CMenu(int pic_background) : CControlContainer(pic_background) {}
 
@@ -27,10 +27,7 @@ bool CMenu::render()
             return false;
     }
 
-    // CSurface::Draw(surface, global::bmpArray[pic_background].surface, 0, 0);
-    auto& surfBG = global::bmpArray[getBackground()].surface;
-    sge_TexturedRect(surface.get(), 0, 0, surface->w - 1, 0, 0, surface->h - 1, surface->w - 1, surface->h - 1,
-                     surfBG.get(), 0, 0, surfBG->w - 1, 0, 0, surfBG->h - 1, surfBG->w - 1, surfBG->h - 1);
+    CSurface::DrawStretched(surface, global::bmpArray[getBackground()].surface);
     renderElements();
     return true;
 }

--- a/CSurface.cpp
+++ b/CSurface.cpp
@@ -8,7 +8,6 @@
 #include "CMap.h"
 #include "Rect.h"
 #include "SGE/sge_blib.h"
-#include "SGE/sge_rotation.h"
 #include "SGE/sge_surface.h"
 #include "globals.h"
 #include "gameData/EdgeDesc.h"
@@ -98,26 +97,57 @@ bool CSurface::Draw(SDL_Surface* Surf_Dest, SDL_Surface* Surf_Src, int X, int Y,
     if(!Surf_Dest || !Surf_Src)
         return false;
 
-    Uint16 px, py;
+    if(angle != 90 && angle != 180 && angle != 270)
+        return false;
 
-    switch(angle)
+    // Simple software rotation for 90/180/270 degrees
+    // 90/270 swap width and height; 180 keeps original dimensions
+    int rotW = (angle == 180) ? Surf_Src->w : Surf_Src->h;
+    int rotH = (angle == 180) ? Surf_Src->h : Surf_Src->w;
+    SDL_Surface* rotated =
+      SDL_CreateRGBSurface(0, rotW, rotH, Surf_Src->format->BitsPerPixel, Surf_Src->format->Rmask,
+                           Surf_Src->format->Gmask, Surf_Src->format->Bmask, Surf_Src->format->Amask);
+    if(!rotated)
+        return false;
+    // Copy palette for 8-bit surfaces
+    if(Surf_Src->format->palette && rotated->format->palette)
+        SDL_SetPaletteColors(rotated->format->palette, Surf_Src->format->palette->colors, 0, 256);
+    SDL_LockSurface(Surf_Src);
+    SDL_LockSurface(rotated);
+    int srcW = Surf_Src->w, srcH = Surf_Src->h, bpp = Surf_Src->format->BytesPerPixel;
+    for(int sy = 0; sy < srcH; sy++)
     {
-        case 90:
-            px = 0;
-            py = Surf_Src->h - 1;
-            break;
-        case 180:
-            px = Surf_Src->w - 1;
-            py = Surf_Src->h - 1;
-            break;
-        case 270:
-            px = Surf_Src->w - 1;
-            py = 0;
-            break;
-        default: return false;
+        for(int sx = 0; sx < srcW; sx++)
+        {
+            int dx, dy;
+            switch(angle)
+            {
+                case 90:
+                    dx = srcH - 1 - sy;
+                    dy = sx;
+                    break;
+                case 180:
+                    dx = srcW - 1 - sx;
+                    dy = srcH - 1 - sy;
+                    break;
+                case 270:
+                    dx = sy;
+                    dy = srcW - 1 - sx;
+                    break;
+                default:
+                    dx = sx;
+                    dy = sy;
+                    break;
+            }
+            memcpy((Uint8*)rotated->pixels + dy * rotated->pitch + dx * bpp,
+                   (Uint8*)Surf_Src->pixels + sy * Surf_Src->pitch + sx * bpp, bpp);
+        }
     }
-
-    sge_transform(Surf_Src, Surf_Dest, (float)angle, 1.0, 1.0, px, py, X, Y, SGE_TSAFE);
+    SDL_UnlockSurface(rotated);
+    SDL_UnlockSurface(Surf_Src);
+    SDL_Rect dst = {(Sint16)X, (Sint16)Y, 0, 0};
+    SDL_BlitSurface(rotated, nullptr, Surf_Dest, &dst);
+    SDL_FreeSurface(rotated);
 
     return true;
 }

--- a/CSurface.cpp
+++ b/CSurface.cpp
@@ -9,12 +9,18 @@
 #include "Rect.h"
 #include "SGE/sge_blib.h"
 #include "SGE/sge_rotation.h"
+#include "SGE/sge_surface.h"
 #include "globals.h"
 #include "gameData/EdgeDesc.h"
 #include "gameData/TerrainDesc.h"
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+
+// Disable SGE's internal surface locking once at startup; terrain drawing is
+// the only remaining consumer of SGE functions and the caller already handles
+// locking. Was originally called in CGame::Init().
+static bool sgeLockOff = (sge_Lock_OFF(), true);
 
 namespace {
 SDL_Rect rect2SDL_Rect(const Rect& rect)
@@ -146,6 +152,27 @@ bool CSurface::Draw(SDL_Surface* Surf_Dest, SDL_Surface* Surf_Src, Position dest
 bool CSurface::Draw(SDL_Surface* Surf_Dest, SdlSurface& Surf_Src, Position dest, Position srcOffset, Extent srcSize)
 {
     return Draw(Surf_Dest, Surf_Src.get(), dest, srcOffset, srcSize);
+}
+
+void CSurface::DrawStretched(SDL_Surface* Surf_Dest, SDL_Surface* Surf_Src)
+{
+    if(!Surf_Dest || !Surf_Src)
+        return;
+
+    // Convert to 32-bit RGB to handle 8-bit paletted sources and drop any
+    // implicit alpha from LBM palette entries (which have a=0).
+    SDL_Surface* converted = SDL_ConvertSurfaceFormat(Surf_Src, SDL_PIXELFORMAT_RGB888, 0);
+    if(!converted)
+        return;
+
+    // Stretch full source to fill full destination
+    SDL_BlitScaled(converted, nullptr, Surf_Dest, nullptr);
+    SDL_FreeSurface(converted);
+}
+
+void CSurface::DrawStretched(SdlSurface& Surf_Dest, SdlSurface& Surf_Src)
+{
+    DrawStretched(Surf_Dest.get(), Surf_Src.get());
 }
 
 // this is the example function from the SDL-documentation to draw pixels

--- a/CSurface.h
+++ b/CSurface.h
@@ -45,7 +45,9 @@ public:
     {
         return Draw(Surf_Dest.get(), Surf_Src.get(), X, Y, X2, Y2, W, H);
     }
-
+    // stretches Surf_Src to fill entire Surf_Dest
+    static void DrawStretched(SDL_Surface* Surf_Dest, SDL_Surface* Surf_Src);
+    static void DrawStretched(SdlSurface& Surf_Dest, SdlSurface& Surf_Src);
     static void DrawPixel_Color(SDL_Surface* screen, Position pos, Uint32 color);
     static void DrawPixel_RGB(SDL_Surface* screen, Position pos, Uint8 R, Uint8 G, Uint8 B);
     static void DrawPixel_RGB(SdlSurface& screen, Position pos, Uint8 R, Uint8 G, Uint8 B)


### PR DESCRIPTION
SGE (SDL Graphics Extension), a abandoned 3rd party vendored library is used in s25edit to draw all triangles in 2D software.

Outside of drawing the triangles & terrain it's used for:
- drawing background images for splash and main menu screens.
- drawing right menubar with 270deg rotation.

This PR converts those to vanilla SDL.

Later when we replace SGE with OpenGL for drawing triangles&terrain, we can delete SGE and use this method to keep drawing it as 2D using SDL. 
Much later the UI should probably be drawn as OpenGL entirely.